### PR TITLE
feat(github): add support for only using the REST API

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -25,6 +25,9 @@ Options:
   --repo-url                    GitHub URL to generate release for    [required]
   --dry-run                     Prepare but do not take action
                                                       [boolean] [default: false]
+  --use-graphql                 Whether or not the GraphQL API should be used.
+                                If false, the REST API will be used instead.
+                                                       [boolean] [default: true]
   --include-v-in-tags           include "v" in tag versions
                                                        [boolean] [default: true]
   --monorepo-tags               include library name in tags and release
@@ -91,6 +94,9 @@ Options:
                         on                                              [string]
   --repo-url            GitHub URL to generate release for            [required]
   --dry-run             Prepare but do not take action[boolean] [default: false]
+  --use-graphql         Whether or not the GraphQL API should be used. If false,
+                        the REST API will be used instead.
+                                                       [boolean] [default: true]
   --label               comma-separated list of labels to add to from release PR
                                                [default: "autorelease: pending"]
   --skip-labeling       skip application of labels to pull requests
@@ -132,6 +138,8 @@ Options:
                                                                         [string]
   --repo-url        GitHub URL to generate release for                [required]
   --dry-run         Prepare but do not take action    [boolean] [default: false]
+  --use-graphql     Whether or not the GraphQL API should be used. If false, the
+                    REST API will be used instead.     [boolean] [default: true]
   --draft           mark release as a draft. no tag is created but tag_name and
                     target_commitish are associated with the release for future
                     tag creation upon "un-drafting" the release.
@@ -179,6 +187,9 @@ Options:
   --repo-url                        GitHub URL to generate release for[required]
   --dry-run                         Prepare but do not take action
                                                       [boolean] [default: false]
+  --use-graphql                     Whether or not the GraphQL API should be
+                                    used. If false, the REST API will be used
+                                    instead.           [boolean] [default: true]
   --release-as                      override the semantically determined release
                                     version                             [string]
   --bump-minor-pre-major            should we bump the semver minor prior to the

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -49,6 +49,7 @@ interface GitHubArgs {
   apiUrl?: string;
   graphqlUrl?: string;
   fork?: boolean;
+  useGraphql?: boolean;
 
   // deprecated in favor of targetBranch
   defaultBranch?: string;
@@ -182,6 +183,12 @@ function gitHubOptions(yargs: yargs.Argv): yargs.Argv {
       describe: 'Prepare but do not take action',
       type: 'boolean',
       default: false,
+    })
+    .option('use-graphql', {
+      describe:
+        'Whether or not the GraphQL API should be used. If false, the REST API will be used instead.',
+      type: 'boolean',
+      default: true,
     })
     .middleware(_argv => {
       const argv = _argv as GitHubArgs;
@@ -792,6 +799,7 @@ async function buildGitHub(argv: GitHubArgs): Promise<GitHub> {
     token: argv.token!,
     apiUrl: argv.apiUrl,
     graphqlUrl: argv.graphqlUrl,
+    useGraphql: argv.useGraphql,
   });
   return github;
 }

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -171,6 +171,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromManifestStub,

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -123,6 +123,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -146,6 +147,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -197,6 +199,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -220,6 +223,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -243,6 +247,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -266,6 +271,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -289,6 +295,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -335,6 +342,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -383,6 +391,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -406,6 +415,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -429,6 +439,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromManifestStub,
@@ -457,6 +468,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -480,6 +492,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -503,6 +516,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -572,6 +586,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromManifestStub,
@@ -597,6 +612,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromManifestStub,
@@ -622,6 +638,7 @@ describe('CLI', () => {
             token: undefined,
             apiUrl: 'https://api.github.com',
             graphqlUrl: 'https://api.github.com',
+            useGraphql: true,
           });
           sinon.assert.calledOnceWithExactly(
             fromManifestStub,
@@ -652,6 +669,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromManifestStub,
@@ -699,6 +717,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -723,6 +742,7 @@ describe('CLI', () => {
             token: undefined,
             apiUrl: 'https://api.github.com',
             graphqlUrl: 'https://api.github.com',
+            useGraphql: true,
           });
           sinon.assert.calledOnceWithExactly(
             fromConfigStub,
@@ -751,6 +771,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -774,6 +795,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -797,6 +819,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -823,6 +846,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -850,6 +874,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -876,6 +901,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -902,6 +928,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -925,6 +952,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -951,6 +979,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -977,6 +1006,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1002,6 +1032,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1025,6 +1056,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1048,6 +1080,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1071,6 +1104,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1094,6 +1128,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1117,6 +1152,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1167,6 +1203,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromManifestStub,
@@ -1190,6 +1227,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromManifestStub,
@@ -1213,6 +1251,7 @@ describe('CLI', () => {
             token: undefined,
             apiUrl: 'https://api.github.com',
             graphqlUrl: 'https://api.github.com',
+            useGraphql: true,
           });
           sinon.assert.calledOnceWithExactly(
             fromManifestStub,
@@ -1241,6 +1280,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromManifestStub,
@@ -1264,6 +1304,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromManifestStub,
@@ -1287,6 +1328,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromManifestStub,
@@ -1341,6 +1383,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1367,6 +1410,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1390,6 +1434,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1413,6 +1458,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1436,6 +1482,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1462,6 +1509,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1485,6 +1533,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1508,6 +1557,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1531,6 +1581,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,


### PR DESCRIPTION
This PR adds support for using the REST API instead of the GraphQL API as the GraphQL API doesn't support fine-grained personal access tokens yet.

This can be specified in the CLI, e.g.

```
release-please release-pr 
  --token=$GITHUB_TOKEN \
  --repo-url=<owner>/<repo>
  --use-graphql=false
```

TODO:
- [x] Update action to support this config, https://github.com/stainless-api/release-please-action/pull/1