### PR TITLE
Check structure of octokit errors instead of via prototype instance

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {GraphqlResponseError} from '@octokit/graphql';
 import {RequestError} from '@octokit/request-error';
 import {RequestError as RequestErrorBody} from '@octokit/types';
 
@@ -90,4 +91,57 @@ export class FileNotFoundError extends Error {
     this.path = path;
     this.name = FileNotFoundError.name;
   }
+}
+
+/**
+ * Type guard to check if an error is an Octokit RequestError.
+ *
+ * This function checks the structure of the error object to determine if it matches
+ * the shape of a RequestError. It should be favored instead of `instanceof` checks,
+ * especially in scenarios where the prototype chain might not be reliable, such as when
+ * dealing with different versions of a package or when the error object might have been
+ * modified.
+ *
+ * @param error The error object to check.
+ * @returns A boolean indicating whether the error is a RequestError.
+ */
+export function isOctokitRequestError(error: unknown): error is RequestError {
+  if (typeof error === 'object' && error !== null) {
+    const e = error as RequestError;
+    return (
+      e.name === 'HttpError' &&
+      typeof e.status === 'number' &&
+      typeof e.request === 'object'
+    );
+  }
+  return false;
+}
+
+/**
+ * Type guard to check if an error is an Octokit GraphqlResponseError.
+ *
+ * This function checks the structure of the error object to determine if it matches
+ * the shape of a GraphqlResponseError. It should be favored instead of `instanceof` checks,
+ * especially in scenarios where the prototype chain might not be reliable, such as when
+ * dealing with different versions of a package or when the error object might have been
+ * modified.
+ *
+ * @param error The error object to check.
+ * @returns A boolean indicating whether the error is a GraphqlResponseError.
+ */
+export function isOctokitGraphqlResponseError(
+  error: unknown
+): error is GraphqlResponseError<unknown> {
+  if (typeof error === 'object' && error !== null) {
+    const e = error as GraphqlResponseError<unknown>;
+    return (
+      typeof e.request === 'object' &&
+      typeof e.headers === 'object' &&
+      typeof e.response === 'object' &&
+      typeof e.name === 'string' &&
+      Array.isArray(e.errors) &&
+      e.data !== undefined
+    );
+  }
+  return false;
 }

--- a/src/github.ts
+++ b/src/github.ts
@@ -22,12 +22,12 @@ import {Commit} from './commit';
 import {Octokit} from '@octokit/rest';
 import {request} from '@octokit/request';
 import {graphql} from '@octokit/graphql';
-import {RequestError} from '@octokit/request-error';
 import {
   GitHubAPIError,
   DuplicateReleaseError,
   FileNotFoundError,
   ConfigurationError,
+  isOctokitRequestError,
 } from './errors';
 
 const MAX_ISSUE_BODY_SIZE = 65536;
@@ -1590,7 +1590,7 @@ export class GitHub {
       };
     },
     e => {
-      if (e instanceof RequestError) {
+      if (isOctokitRequestError(e)) {
         if (
           e.status === 422 &&
           GitHubAPIError.parseErrors(e).some(error => {
@@ -1754,7 +1754,7 @@ export class GitHub {
       this.logger.debug(`SHA for branch: ${sha}`);
       return sha;
     } catch (e) {
-      if (e instanceof RequestError && e.status === 404) {
+      if (isOctokitRequestError(e) && e.status === 404) {
         this.logger.debug(`Branch: ${branchName} does not exist`);
         return undefined;
       }
@@ -2079,7 +2079,7 @@ const wrapAsync = <T extends Array<any>, V>(
       if (errorHandler) {
         errorHandler(e as GitHubAPIError);
       }
-      if (e instanceof RequestError) {
+      if (isOctokitRequestError(e)) {
         throw new GitHubAPIError(e);
       }
       throw e;

--- a/test/errors/index.ts
+++ b/test/errors/index.ts
@@ -1,0 +1,69 @@
+import {expect} from 'chai';
+import {GraphqlResponseError} from '@octokit/graphql';
+import {
+  isOctokitGraphqlResponseError,
+  isOctokitRequestError,
+} from '../../src/errors';
+import {RequestError} from '@octokit/request-error';
+
+describe('Errors', () => {
+  describe('isOctokitRequestError', () => {
+    it('should return true for valid RequestError', () => {
+      const error = new RequestError('Not Found', 404, {
+        request: {method: 'GET', url: '/foo/bar', headers: {}},
+        headers: {},
+      });
+      expect(isOctokitRequestError(error)).to.be.true;
+    });
+
+    it('should return false for invalid RequestError', () => {
+      const error = {
+        name: 'SomeOtherError',
+        status: 500,
+        request: 'invalid_request_object',
+      };
+      expect(isOctokitRequestError(error)).to.be.false;
+    });
+  });
+
+  describe('isOctokitGraphqlResponseError', () => {
+    it('should return true for valid GraphqlResponseError', () => {
+      const error = new GraphqlResponseError(
+        {
+          method: 'GET',
+          url: '/foo/bar',
+        },
+        {},
+        {
+          data: {},
+          errors: [
+            {
+              type: 'FORBIDDEN',
+              message: 'Resource not accessible by integration',
+              path: ['foo'],
+              extensions: {},
+              locations: [
+                {
+                  line: 123,
+                  column: 456,
+                },
+              ],
+            },
+          ],
+        }
+      );
+      expect(isOctokitGraphqlResponseError(error)).to.be.true;
+    });
+
+    it('should return false for invalid GraphqlResponseError', () => {
+      const error = {
+        request: {},
+        headers: {},
+        response: {},
+        name: 'SomeOtherError',
+        errors: [],
+      };
+      expect(isOctokitGraphqlResponseError(error)).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
That was a fun one.

A bit of context. As part of https://github.com/stainless-api/stainless/pull/2129 I am trying to debug an issue where `getBranchSha` throws an exception when it receives a GitHub 404 response. That was really surprising given the call to GitHub is wraps in a `try/catch` to handle that case:

```typescript
    try {
      const {
        data: {
          object: {sha},
        },
      } = await this.octokit.git.getRef({
        owner: this.repository.owner,
        repo: this.repository.repo,
        ref: `heads/${branchName}`,
      });
      this.logger.debug(`SHA for branch: ${sha}`);
      return sha;
    } catch (e) {
      // 👇 relevant code
      if (e instanceof RequestError && e.status === 404) {
        this.logger.debug(`Branch: ${branchName} does not exist`);
        return undefined;
      }
      throw e;
    }
```

By digging more into the generated JS and trying to debug it at runtime I can see that the constructor of the caught error is named "RequestError`, as expected, but the `instanceof` still returns `false` for both the imported `octokit.RequestError` and `@octokit/request-errors.RequestError`, pointing to a dependency mismatch.

By running `yarn list @octokit/request-error` I can see that between the project in Stainless repository and dependencies from `release-please` we have widely different versions of octokit packages. Unfortunately we cannot easily bump the octokit version used by `release-please`, octokit v3 requires node v18+ but `release-please` tests cannot be run with node v18+ (see https://github.com/stainless-api/release-please/pull/5).

So, long story short: this pull request uses type guards to structurally check octokit errors instead of relying on imported packages, side-stepping any dependency issue.