### PR TITLE
ignore add reviewer errors

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -1337,12 +1337,20 @@ export class GitHub {
 
       // assign reviewers
       if (options?.reviewers) {
-        await this.octokit.pulls.requestReviewers({
-          owner: this.repository.owner,
-          repo: this.repository.repo,
-          pull_number: pullRequestNumber,
-          reviewers: options.reviewers,
-        });
+        try {
+          await this.octokit.pulls.requestReviewers({
+            owner: this.repository.owner,
+            repo: this.repository.repo,
+            pull_number: pullRequestNumber,
+            reviewers: options.reviewers,
+          });
+        } catch (error) {
+          console.log(
+            `Failed to add reviewers. Continuing anyway: ${
+              isOctokitRequestError(error) ? error.message : error
+            }`
+          );
+        }
       }
 
       return await this.getPullRequest(pullRequestNumber);


### PR DESCRIPTION
Not all repos allow reviewers to be added. We use this feature so we get notifications when a PR is opened, but if that doesn't happen (because we can't add reviewers), it is no big deal. We don't want PR creation to fail just because of the reviewer add failing.

This makes this release-please more and more specific to our use case, but oh well
