### PR TITLE
Create pre-release when release PR labelled as 'autorelease: pre-rele…

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -64,6 +64,9 @@ Options:
   --release-label               set a pull request label other than
                                 "autorelease: tagged"
                                        [string] [default: "autorelease: tagged"]
+  --prerelease-label            set a pre-release pull request label other than
+                                "autorelease: pre-release"
+                                  [string] [default: "autorelease: pre-release"]
   --snapshot-label              set a java snapshot pull request label other
                                 than "autorelease: snapshot"
                                      [string] [default: "autorelease: snapshot"]
@@ -122,43 +125,47 @@ release-please manifest-release
 create releases/tags from last release-PR using a manifest file
 
 Options:
-  --help            Show help                                          [boolean]
-  --version         Show version number                                [boolean]
-  --debug           print verbose errors (use only for local debugging).
+  --help              Show help                                        [boolean]
+  --version           Show version number                              [boolean]
+  --debug             print verbose errors (use only for local debugging).
                                                       [boolean] [default: false]
-  --trace           print extra verbose errors (use only for local debugging).
+  --trace             print extra verbose errors (use only for local debugging).
                                                       [boolean] [default: false]
-  --plugin          load plugin named release-please-<plugin-name>
+  --plugin            load plugin named release-please-<plugin-name>
                                                            [array] [default: []]
-  --token           GitHub token with repo write permissions
-  --api-url         URL to use when making API requests
+  --token             GitHub token with repo write permissions
+  --api-url           URL to use when making API requests
                                     [string] [default: "https://api.github.com"]
-  --graphql-url     URL to use when making GraphQL requests
+  --graphql-url       URL to use when making GraphQL requests
                                     [string] [default: "https://api.github.com"]
-  --default-branch  The branch to open release PRs against and tag releases on
+  --default-branch    The branch to open release PRs against and tag releases on
                               [deprecated: use --target-branch instead] [string]
-  --target-branch   The branch to open release PRs against and tag releases on
+  --target-branch     The branch to open release PRs against and tag releases on
                                                                         [string]
-  --repo-url        GitHub URL to generate release for                [required]
-  --dry-run         Prepare but do not take action    [boolean] [default: false]
-  --use-graphql     Whether or not the GraphQL API should be used. If false, the
-                    REST API will be used instead.     [boolean] [default: true]
-  --draft           mark release as a draft. no tag is created but tag_name and
-                    target_commitish are associated with the release for future
-                    tag creation upon "un-drafting" the release.
+  --repo-url          GitHub URL to generate release for              [required]
+  --dry-run           Prepare but do not take action  [boolean] [default: false]
+  --use-graphql       Whether or not the GraphQL API should be used. If false,
+                      the REST API will be used instead.
+                                                       [boolean] [default: true]
+  --draft             mark release as a draft. no tag is created but tag_name
+                      and target_commitish are associated with the release for
+                      future tag creation upon "un-drafting" the release.
                                                       [boolean] [default: false]
-  --prerelease      mark release that have prerelease versions as as a
-                    prerelease on Github              [boolean] [default: false]
-  --label           comma-separated list of labels to remove to from release PR
-                                               [default: "autorelease: pending"]
-  --release-label   set a pull request label other than "autorelease: tagged"
+  --prerelease        mark release that have prerelease versions as as a
+                      prerelease on Github            [boolean] [default: false]
+  --label             comma-separated list of labels to remove to from release
+                      PR                       [default: "autorelease: pending"]
+  --release-label     set a pull request label other than "autorelease: tagged"
                                        [string] [default: "autorelease: tagged"]
-  --snapshot-label  set a java snapshot pull request label other than
-                    "autorelease: snapshot"
+  --prerelease-label  set a pre-release pull request label other than
+                      "autorelease: pre-release"
+                                  [string] [default: "autorelease: pre-release"]
+  --snapshot-label    set a java snapshot pull request label other than
+                      "autorelease: snapshot"
                                      [string] [default: "autorelease: snapshot"]
-  --config-file     where can the config file be found in the project?
+  --config-file       where can the config file be found in the project?
                                          [default: "release-please-config.json"]
-  --manifest-file   where can the manifest file be found in the project?
+  --manifest-file     where can the manifest file be found in the project?
                                       [default: ".release-please-manifest.json"]
 `
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -68,7 +68,7 @@ Extra options:
 ## Creating/updating release PRs
 
 ```bash
-release-please release-pr 
+release-please release-pr
   --token=$GITHUB_TOKEN \
   --repo-url=<owner>/<repo> [extra options]
 ```

--- a/schemas/config.json
+++ b/schemas/config.json
@@ -43,7 +43,10 @@
                 "type": "boolean"
               }
             },
-            "required": ["type", "section"]
+            "required": [
+              "type",
+              "section"
+            ]
           }
         },
         "release-as": {
@@ -81,7 +84,10 @@
         "changelog-type": {
           "description": "The type of changelog to use. Defaults to `default`.",
           "type": "string",
-          "enum": ["default", "github"]
+          "enum": [
+            "default",
+            "github"
+          ]
         },
         "changelog-host": {
           "description": "Generate changelog links to this GitHub host. Useful for running against GitHub Enterprise.",
@@ -122,7 +128,11 @@
                 "properties": {
                   "type": {
                     "description": "The file format type.",
-                    "enum": ["json", "toml", "yaml"]
+                    "enum": [
+                      "json",
+                      "toml",
+                      "yaml"
+                    ]
                   },
                   "path": {
                     "description": "The path to the file.",
@@ -137,7 +147,11 @@
                     "type": "string"
                   }
                 },
-                "required": ["type", "path", "jsonpath"]
+                "required": [
+                  "type",
+                  "path",
+                  "jsonpath"
+                ]
               },
               {
                 "description": "An extra XML file with a targeted update via xpath.",
@@ -145,7 +159,9 @@
                 "properties": {
                   "type": {
                     "description": "The file format type.",
-                    "enum": ["xml"]
+                    "enum": [
+                      "xml"
+                    ]
                   },
                   "path": {
                     "description": "The path to the file.",
@@ -160,7 +176,11 @@
                     "type": "string"
                   }
                 },
-                "required": ["type", "path", "xpath"]
+                "required": [
+                  "type",
+                  "path",
+                  "xpath"
+                ]
               },
               {
                 "description": "An extra pom.xml file.",
@@ -168,7 +188,9 @@
                 "properties": {
                   "type": {
                     "description": "The file format type.",
-                    "enum": ["pom"]
+                    "enum": [
+                      "pom"
+                    ]
                   },
                   "path": {
                     "description": "The path to the file.",
@@ -179,7 +201,10 @@
                     "type": "boolean"
                   }
                 },
-                "required": ["type", "path"]
+                "required": [
+                  "type",
+                  "path"
+                ]
               }
             ]
           }
@@ -256,7 +281,9 @@
                   "type": {
                     "description": "The name of the plugin.",
                     "type": "string",
-                    "enum": ["linked-versions"]
+                    "enum": [
+                      "linked-versions"
+                    ]
                   },
                   "groupName": {
                     "description": "The name of the group of components.",
@@ -281,7 +308,11 @@
                     }
                   }
                 },
-                "required": ["type", "groupName", "components"]
+                "required": [
+                  "type",
+                  "groupName",
+                  "components"
+                ]
               },
               {
                 "description": "Configuration for various `workspace` plugins.",
@@ -290,7 +321,11 @@
                   "type": {
                     "description": "The name of the plugin.",
                     "type": "string",
-                    "enum": ["cargo-workspace", "maven-workspace", "node-workspace"]
+                    "enum": [
+                      "cargo-workspace",
+                      "maven-workspace",
+                      "node-workspace"
+                    ]
                   },
                   "updateAllPackages": {
                     "description": "Whether to force updating all packages regardless of the dependency tree. Defaults to `false`.",
@@ -313,7 +348,9 @@
                   "type": {
                     "description": "The name of the plugin.",
                     "type": "string",
-                    "enum": ["group-priority"]
+                    "enum": [
+                      "group-priority"
+                    ]
                   },
                   "groups": {
                     "description": "Group names ordered with highest priority first.",
@@ -360,9 +397,15 @@
         "release-label": {
           "description": "Comma-separated list of labels to add to a pull request that has been released/tagged",
           "type": "string"
+        },
+        "prerelease-label": {
+          "description": "Comma-separated list of labels to add to a pull request to denote the release should be marked as pre-release",
+          "type": "string"
         }
       },
-      "required": ["packages"]
+      "required": [
+        "packages"
+      ]
     }
   ],
   "properties": {
@@ -388,6 +431,7 @@
     "draft-pull-request": true,
     "label": true,
     "release-label": true,
+    "prerelease-label": true,
     "extra-label": true,
     "include-component-in-tag": true,
     "include-v-in-tag": true,

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -87,6 +87,7 @@ interface ReleaseArgs {
   draft?: boolean;
   prerelease?: boolean;
   releaseLabel?: string;
+  prereleaseLabel?: string;
   snapshotLabel?: string;
   label?: string;
 }
@@ -225,6 +226,12 @@ function releaseOptions(yargs: yargs.Argv): yargs.Argv {
     .option('release-label', {
       describe: 'set a pull request label other than "autorelease: tagged"',
       default: 'autorelease: tagged',
+      type: 'string',
+    })
+    .option('prerelease-label', {
+      describe:
+        'set a pre-release pull request label other than "autorelease: pre-release"',
+      default: 'autorelease: pre-release',
       type: 'string',
     })
     .option('snapshot-label', {
@@ -886,6 +893,9 @@ function extractManifestOptions(
   }
   if ('releaseLabel' in argv && argv.releaseLabel) {
     manifestOptions.releaseLabels = argv.releaseLabel.split(',');
+  }
+  if ('prereleaseLabel' in argv && argv.prereleaseLabel) {
+    manifestOptions.prereleaseLabels = argv.prereleaseLabel.split(',');
   }
   if ('snapshotLabel' in argv && argv.snapshotLabel) {
     manifestOptions.snapshotLabels = argv.snapshotLabel.split(',');

--- a/src/github.ts
+++ b/src/github.ts
@@ -1979,16 +1979,27 @@ export class GitHub {
 
   async getLabels(): Promise<string[]> {
     const {owner, repo} = this.repository;
-    const labels = await this.request('GET /repos/{owner}/{repo}/labels', {
-      owner,
-      repo,
-    });
-    return labels.data.map(l => l.name);
+    this.logger.info(`Fetch labels from repo ${owner}/${repo}`);
+    const labels: string[] = [];
+    for await (const page of this.octokit.paginate.iterator(
+      'GET /repos/{owner}/{repo}/labels',
+      {
+        owner,
+        repo,
+      }
+    )) {
+      for (const label of page.data) {
+        labels.push(label.name);
+      }
+    }
+    this.logger.debug(`Found ${labels.length} labels: ${labels.join(', ')}`);
+    return labels;
   }
 
   async createLabels(labels: string[]) {
     const {owner, repo} = this.repository;
     for (const label of labels) {
+      this.logger.info(`Creating label '${label}' for repo ${owner}/${repo}`);
       await this.request('POST /repos/{owner}/{repo}/labels', {
         owner,
         repo,

--- a/src/github.ts
+++ b/src/github.ts
@@ -1976,6 +1976,29 @@ export class GitHub {
       force: true,
     });
   }
+
+  async getLabels(): Promise<string[]> {
+    const {owner, repo} = this.repository;
+    const labels = await this.request('GET /repos/{owner}/{repo}/labels', {
+      owner,
+      repo,
+    });
+    return labels.data.map(l => l.name);
+  }
+
+  async createLabels(labels: string[]) {
+    const {owner, repo} = this.repository;
+    for (const label of labels) {
+      await this.request('POST /repos/{owner}/{repo}/labels', {
+        owner,
+        repo,
+        name: label,
+        headers: {
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      });
+    }
+  }
 }
 
 /**

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1344,7 +1344,7 @@ export class Manifest {
     }
 
     const adjustPullRequestTags = async () => {
-      // Note: if the pull request represents moret than one release it becomes difficult to determine if it should be
+      // Note: if the pull request represents more than one release it becomes difficult to determine if it should be
       // labelled as pre-release.
       const isPrerelease = releases.length === 1 && releases[0].prerelease;
       await Promise.all([

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -113,6 +113,7 @@ export interface ReleaserConfig {
   separatePullRequests?: boolean;
   labels?: string[];
   releaseLabels?: string[];
+  prereleaseLabels?: string[];
   extraLabels?: string[];
   initialVersion?: string;
 
@@ -158,6 +159,7 @@ interface ReleaserConfigJson {
   'draft-pull-request'?: boolean;
   label?: string;
   'release-label'?: string;
+  'prerelease-label'?: string;
   'extra-label'?: string;
   'include-component-in-tag'?: boolean;
   'include-v-in-tag'?: boolean;
@@ -186,6 +188,7 @@ export interface ManifestOptions {
   manifestPath?: string;
   labels?: string[];
   releaseLabels?: string[];
+  prereleaseLabels?: string[];
   snapshotLabels?: string[];
   skipLabeling?: boolean;
   sequentialCalls?: boolean;
@@ -260,6 +263,7 @@ export const DEFAULT_LABELS = ['autorelease: pending'];
 export const DEFAULT_RELEASE_LABELS = ['autorelease: tagged'];
 export const DEFAULT_SNAPSHOT_LABELS = ['autorelease: snapshot'];
 export const SNOOZE_LABEL = 'autorelease: snooze';
+export const DEFAULT_PRERELEASE_LABELS = ['autorelease: pre-release'];
 const DEFAULT_RELEASE_SEARCH_DEPTH = 400;
 const DEFAULT_COMMIT_SEARCH_DEPTH = 500;
 
@@ -288,6 +292,7 @@ export class Manifest {
   private skipLabeling?: boolean;
   private sequentialCalls?: boolean;
   private releaseLabels: string[];
+  private prereleaseLabels: string[];
   private snapshotLabels: string[];
   readonly plugins: ManifestPlugin[];
   private _strategiesByPath?: Record<string, Strategy>;
@@ -328,6 +333,8 @@ export class Manifest {
    *   pull request. Defaults to `[autorelease: pending]`
    * @param {string[]} manifestOptions.releaseLabels Labels to apply to a tagged release
    *   pull request. Defaults to `[autorelease: tagged]`
+   * @param {string[]} manifestOptions.prereleaseLabels Labels that denote a pre-release pull request.
+   *   Defaults to `[autorelease: pre-release]`
    */
   constructor(
     github: GitHub,
@@ -351,6 +358,8 @@ export class Manifest {
     this.signoffUser = manifestOptions?.signoff;
     this.releaseLabels =
       manifestOptions?.releaseLabels || DEFAULT_RELEASE_LABELS;
+    this.prereleaseLabels =
+      manifestOptions?.prereleaseLabels || DEFAULT_PRERELEASE_LABELS;
     this.labels = manifestOptions?.labels || DEFAULT_LABELS;
     this.skipLabeling = manifestOptions?.skipLabeling || false;
     this.sequentialCalls = manifestOptions?.sequentialCalls || false;
@@ -446,6 +455,8 @@ export class Manifest {
    *   pull request. Defaults to `[autorelease: pending]`
    * @param {string[]} manifestOptions.releaseLabels Labels to apply to a tagged release
    *   pull request. Defaults to `[autorelease: tagged]`
+   * @param {string[]} manifestOptions.prereleaseLabels Labels that denote a pre-release pull request.
+   *   Defaults to `[autorelease: pre-release]`
    * @returns {Manifest}
    */
   static async fromConfig(
@@ -1097,6 +1108,11 @@ export class Manifest {
         const releases = await strategy.buildReleases(pullRequest, {
           groupPullRequestTitlePattern: this.groupPullRequestTitlePattern,
         });
+        const hasPrereleaseLabel = !!pullRequest.labels.find(label =>
+          this.prereleaseLabels.find(
+            prereleaseLabel => prereleaseLabel === label
+          )
+        );
         for (const release of releases) {
           candidateReleases.push({
             ...release,
@@ -1104,9 +1120,10 @@ export class Manifest {
             pullRequest,
             draft: config.draft ?? this.draft,
             prerelease:
-              config.prerelease &&
-              (!!release.tag.version.preRelease ||
-                release.tag.version.major === 0),
+              hasPrereleaseLabel ||
+              (config.prerelease &&
+                (!!release.tag.version.preRelease ||
+                  release.tag.version.major === 0)),
           });
         }
       }
@@ -1313,28 +1330,36 @@ export class Manifest {
       }
     }
 
+    const adjustPullRequestTags = async () => {
+      // Note: if the pull request represents moret than one release it becomes difficult to determine if it should be
+      // labelled as pre-release.
+      const isPrerelease = releases.length === 1 && releases[0].prerelease;
+      await Promise.all([
+        this.github.removeIssueLabels(this.labels, pullRequest.number),
+        this.github.addIssueLabels(
+          [
+            ...this.releaseLabels,
+            ...(isPrerelease ? this.prereleaseLabels : []),
+          ],
+          pullRequest.number
+        ),
+      ]);
+    };
+
     if (duplicateReleases.length > 0) {
       if (
         duplicateReleases.length + githubReleases.length ===
         releases.length
       ) {
-        // we've either tagged all releases or they were duplicates:
-        // adjust tags on pullRequest
-        await Promise.all([
-          this.github.removeIssueLabels(this.labels, pullRequest.number),
-          this.github.addIssueLabels(this.releaseLabels, pullRequest.number),
-        ]);
+        // we've either tagged all releases or they were duplicates
+        await adjustPullRequestTags();
       }
       if (githubReleases.length === 0) {
         // If all releases were duplicate, throw a duplicate error
         throw duplicateReleases[0];
       }
     } else {
-      // adjust tags on pullRequest
-      await Promise.all([
-        this.github.removeIssueLabels(this.labels, pullRequest.number),
-        this.github.addIssueLabels(this.releaseLabels, pullRequest.number),
-      ]);
+      await adjustPullRequestTags();
     }
 
     return githubReleases;
@@ -1437,6 +1462,7 @@ function extractReleaserConfig(
     separatePullRequests: config['separate-pull-requests'],
     labels: config['label']?.split(','),
     releaseLabels: config['release-label']?.split(','),
+    prereleaseLabels: config['prerelease-label']?.split(','),
     extraLabels: config['extra-label']?.split(','),
     skipSnapshot: config['skip-snapshot'],
     initialVersion: config['initial-version'],
@@ -1476,6 +1502,7 @@ async function parseConfig(
   }
   const configLabel = config['label'];
   const configReleaseLabel = config['release-label'];
+  const configPreReleaseLabel = config['prerelease-label'];
   const configSnapshotLabel = config['snapshot-label'];
   const configExtraLabel = config['extra-label'];
   const manifestOptions = {
@@ -1487,6 +1514,7 @@ async function parseConfig(
     plugins: config['plugins'],
     labels: configLabel?.split(','),
     releaseLabels: configReleaseLabel?.split(','),
+    prereleaseLabels: configPreReleaseLabel?.split(','),
     snapshotLabels: configSnapshotLabel?.split(','),
     extraLabels: configExtraLabel?.split(','),
     releaseSearchDepth: config['release-search-depth'],

--- a/src/updaters/release-please-config.ts
+++ b/src/updaters/release-please-config.ts
@@ -69,6 +69,7 @@ function releaserConfigToJsonConfig(
     'draft-pull-request': config.draftPullRequest,
     label: config.labels?.join(','),
     'release-label': config.releaseLabels?.join(','),
+    'prerelease-label': config.prereleaseLabels?.join(','),
     'include-component-in-tag': config.includeComponentInTag,
     'include-v-in-tag': config.includeVInTag,
     'changelog-type': config.changelogType,

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -482,9 +482,9 @@ describe('CLI', () => {
       sinon.assert.calledOnce(buildReleasesStub);
     });
 
-    it('handles --label and --release-label', async () => {
+    it('handles --label, --release-label, and --prerelease-label', async () => {
       await parser.parseAsync(
-        'manifest-release --repo-url=googleapis/release-please-cli --label=foo,bar --release-label=asdf,qwer'
+        'manifest-release --repo-url=googleapis/release-please-cli --label=foo,bar --release-label=asdf,qwer --prerelease-label=preview1,preview2'
       );
 
       sinon.assert.calledOnceWithExactly(gitHubCreateStub, {
@@ -501,7 +501,11 @@ describe('CLI', () => {
         'main',
         DEFAULT_RELEASE_PLEASE_CONFIG,
         DEFAULT_RELEASE_PLEASE_MANIFEST,
-        sinon.match({labels: ['foo', 'bar'], releaseLabels: ['asdf', 'qwer']})
+        sinon.match({
+          labels: ['foo', 'bar'],
+          releaseLabels: ['asdf', 'qwer'],
+          prereleaseLabels: ['preview1', 'preview2'],
+        })
       );
       sinon.assert.calledOnce(createReleasesStub);
     });
@@ -1294,9 +1298,9 @@ describe('CLI', () => {
         sinon.assert.calledOnce(buildReleasesStub);
       });
 
-      it('handles --label and --release-label', async () => {
+      it('handles --label, --release-label, and --prerelease-label', async () => {
         await parser.parseAsync(
-          'github-release --repo-url=googleapis/release-please-cli --label=foo,bar --release-label=asdf,qwer'
+          'github-release --repo-url=googleapis/release-please-cli --label=foo,bar --release-label=asdf,qwer --prerelease-label=preview1,preview2'
         );
 
         sinon.assert.calledOnceWithExactly(gitHubCreateStub, {
@@ -1313,7 +1317,11 @@ describe('CLI', () => {
           'main',
           DEFAULT_RELEASE_PLEASE_CONFIG,
           DEFAULT_RELEASE_PLEASE_MANIFEST,
-          sinon.match({labels: ['foo', 'bar'], releaseLabels: ['asdf', 'qwer']})
+          sinon.match({
+            labels: ['foo', 'bar'],
+            releaseLabels: ['asdf', 'qwer'],
+            prereleaseLabels: ['preview1', 'preview2'],
+          })
         );
         sinon.assert.calledOnce(createReleasesStub);
       });
@@ -1472,9 +1480,9 @@ describe('CLI', () => {
         sinon.assert.calledOnce(createReleasesStub);
       });
 
-      it('handles --label and --release-label', async () => {
+      it('handles --label, --release-label, and prerelease-label', async () => {
         await parser.parseAsync(
-          'github-release --repo-url=googleapis/release-please-cli --release-type=java-yoshi --label=foo,bar --release-label=asdf,qwer'
+          'github-release --repo-url=googleapis/release-please-cli --release-type=java-yoshi --label=foo,bar --release-label=asdf,qwer --prerelease-label=preview1,preview2'
         );
 
         sinon.assert.calledOnceWithExactly(gitHubCreateStub, {
@@ -1493,6 +1501,7 @@ describe('CLI', () => {
           sinon.match({
             labels: ['foo', 'bar'],
             releaseLabels: ['asdf', 'qwer'],
+            prereleaseLabels: ['preview1', 'preview2'],
           }),
           undefined
         );

--- a/test/fixtures/manifest/config/exclude-paths.json
+++ b/test/fixtures/manifest/config/exclude-paths.json
@@ -2,11 +2,16 @@
   "release-type": "simple",
   "label": "custom: pending",
   "release-label": "custom: tagged",
-  "exclude-paths": ["path-ignore"],
+  "prerelease-label": "custom: pre-release",
+  "exclude-paths": [
+    "path-ignore"
+  ],
   "packages": {
     ".": {
       "component": "root",
-      "exclude-paths": ["path-root-ignore"]
+      "exclude-paths": [
+        "path-root-ignore"
+      ]
     },
     "node-lib": {
       "component": "node-lib"

--- a/test/fixtures/manifest/config/extra-labels.json
+++ b/test/fixtures/manifest/config/extra-labels.json
@@ -2,6 +2,7 @@
   "release-type": "simple",
   "label": "custom: pending",
   "release-label": "custom: tagged",
+  "prerelease-label": "custom: pre-release",
   "extra-label": "lang: java",
   "packages": {
     ".": {

--- a/test/fixtures/manifest/config/labels.json
+++ b/test/fixtures/manifest/config/labels.json
@@ -2,6 +2,7 @@
   "release-type": "simple",
   "label": "custom: pending",
   "release-label": "custom: tagged",
+  "prerelease-label": "custom: pre-release",
   "packages": {
     ".": {
       "component": "root"

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -3436,8 +3436,18 @@ describe('Manifest', () => {
         }
       );
       sandbox.stub(manifest, 'buildPullRequests').resolves([]);
+      const getLabelsStub = sandbox
+        .stub(github, 'getLabels')
+        .resolves(['label-a', 'label-b']);
+      const createLabelsStub = sandbox.stub(github, 'createLabels').resolves();
       const pullRequests = await manifest.createPullRequests();
       expect(pullRequests).to.be.empty;
+      sinon.assert.calledOnce(getLabelsStub);
+      sinon.assert.calledOnceWithExactly(createLabelsStub, [
+        'autorelease: pending',
+        'autorelease: tagged',
+        'autorelease: pre-release',
+      ]);
     });
 
     it('handles a single pull request', async () => {
@@ -3516,8 +3526,18 @@ describe('Manifest', () => {
           draft: false,
         },
       ]);
+      const getLabelsStub = sandbox
+        .stub(github, 'getLabels')
+        .resolves(['label-a', 'label-b']);
+      const createLabelsStub = sandbox.stub(github, 'createLabels').resolves();
       const pullRequests = await manifest.createPullRequests();
       expect(pullRequests).lengthOf(1);
+      sinon.assert.calledOnce(getLabelsStub);
+      sinon.assert.calledOnceWithExactly(createLabelsStub, [
+        'autorelease: pending',
+        'autorelease: tagged',
+        'autorelease: pre-release',
+      ]);
     });
 
     it('handles a multiple pull requests', async () => {
@@ -3646,9 +3666,19 @@ describe('Manifest', () => {
           draft: false,
         },
       ]);
+      const getLabelsStub = sandbox
+        .stub(github, 'getLabels')
+        .resolves(['label-a', 'label-b']);
+      const createLabelsStub = sandbox.stub(github, 'createLabels').resolves();
       const pullRequests = await manifest.createPullRequests();
       expect(pullRequests.map(pullRequest => pullRequest!.number)).to.eql([
         123, 124,
+      ]);
+      sinon.assert.calledOnce(getLabelsStub);
+      sinon.assert.calledOnceWithExactly(createLabelsStub, [
+        'autorelease: pending',
+        'autorelease: tagged',
+        'autorelease: pre-release',
       ]);
     });
 
@@ -3729,8 +3759,18 @@ describe('Manifest', () => {
           draft: false,
         },
       ]);
+      const getLabelsStub = sandbox
+        .stub(github, 'getLabels')
+        .resolves(['label-a', 'label-b']);
+      const createLabelsStub = sandbox.stub(github, 'createLabels').resolves();
       const pullRequestNumbers = await manifest.createPullRequests();
       expect(pullRequestNumbers).lengthOf(1);
+      sinon.assert.calledOnce(getLabelsStub);
+      sinon.assert.calledOnceWithExactly(createLabelsStub, [
+        'autorelease: pending',
+        'autorelease: tagged',
+        'autorelease: pre-release',
+      ]);
     });
 
     it('handles fork = true', async () => {
@@ -3810,8 +3850,18 @@ describe('Manifest', () => {
           draft: false,
         },
       ]);
+      const getLabelsStub = sandbox
+        .stub(github, 'getLabels')
+        .resolves(['label-a', 'label-b']);
+      const createLabelsStub = sandbox.stub(github, 'createLabels').resolves();
       const pullRequestNumbers = await manifest.createPullRequests();
       expect(pullRequestNumbers).lengthOf(1);
+      sinon.assert.calledOnce(getLabelsStub);
+      sinon.assert.calledOnceWithExactly(createLabelsStub, [
+        'autorelease: pending',
+        'autorelease: tagged',
+        'autorelease: pre-release',
+      ]);
     });
 
     it('updates an existing pull request', async () => {
@@ -3907,8 +3957,18 @@ describe('Manifest', () => {
           draft: false,
         },
       ]);
+      const getLabelsStub = sandbox
+        .stub(github, 'getLabels')
+        .resolves(['label-a', 'label-b']);
+      const createLabelsStub = sandbox.stub(github, 'createLabels').resolves();
       const pullRequestNumbers = await manifest.createPullRequests();
       expect(pullRequestNumbers).lengthOf(1);
+      sinon.assert.calledOnce(getLabelsStub);
+      sinon.assert.calledOnceWithExactly(createLabelsStub, [
+        'autorelease: pending',
+        'autorelease: tagged',
+        'autorelease: pre-release',
+      ]);
     });
 
     describe('with an overflowing body', () => {
@@ -3990,9 +4050,21 @@ describe('Manifest', () => {
               draft: false,
             },
           ]);
+        const getLabelsStub = sandbox
+          .stub(github, 'getLabels')
+          .resolves(['label-a', 'label-b']);
+        const createLabelsStub = sandbox
+          .stub(github, 'createLabels')
+          .resolves();
         const pullRequestNumbers = await manifest.createPullRequests();
         sinon.assert.calledOnce(updatePullRequestStub);
         sinon.assert.calledOnce(buildPullRequestsStub);
+        sinon.assert.calledOnce(getLabelsStub);
+        sinon.assert.calledOnceWithExactly(createLabelsStub, [
+          'autorelease: pending',
+          'autorelease: tagged',
+          'autorelease: pre-release',
+        ]);
         expect(pullRequestNumbers).lengthOf(1);
       });
 
@@ -4076,6 +4148,12 @@ describe('Manifest', () => {
             plugins: ['node-workspace'],
           }
         );
+        const getLabelsStub = sandbox
+          .stub(github, 'getLabels')
+          .resolves(['label-a', 'label-b', 'autorelease: pending']);
+        const createLabelsStub = sandbox
+          .stub(github, 'createLabels')
+          .resolves();
         sandbox.stub(manifest, 'buildPullRequests').resolves([
           {
             title: PullRequestTitle.ofTargetBranch('main', 'main'),
@@ -4094,6 +4172,11 @@ describe('Manifest', () => {
         ]);
         const pullRequestNumbers = await manifest.createPullRequests();
         expect(pullRequestNumbers).lengthOf(0);
+        sinon.assert.calledOnce(getLabelsStub);
+        sinon.assert.calledOnceWithExactly(createLabelsStub, [
+          'autorelease: tagged',
+          'autorelease: pre-release',
+        ]);
       });
     });
 
@@ -4169,6 +4252,10 @@ describe('Manifest', () => {
           separatePullRequests: true,
         }
       );
+      const getLabelsStub = sandbox
+        .stub(github, 'getLabels')
+        .resolves(['label-a', 'label-b', 'autorelease: pending']);
+      const createLabelsStub = sandbox.stub(github, 'createLabels').resolves();
       sandbox.stub(manifest, 'buildPullRequests').resolves([
         {
           title: PullRequestTitle.ofTargetBranch('main', 'main'),
@@ -4191,6 +4278,11 @@ describe('Manifest', () => {
       ]);
       const pullRequestNumbers = await manifest.createPullRequests();
       expect(pullRequestNumbers).lengthOf(1);
+      sinon.assert.calledOnce(getLabelsStub);
+      sinon.assert.calledOnceWithExactly(createLabelsStub, [
+        'autorelease: tagged',
+        'autorelease: pre-release',
+      ]);
     });
 
     it('skips pull requests if there are pending, merged pull requests', async () => {
@@ -4255,8 +4347,18 @@ describe('Manifest', () => {
           draft: false,
         },
       ]);
+      const getLabelsStub = sandbox
+        .stub(github, 'getLabels')
+        .resolves(['label-a', 'label-b']);
+      const createLabelsStub = sandbox.stub(github, 'createLabels').resolves();
       const pullRequestNumbers = await manifest.createPullRequests();
       expect(pullRequestNumbers).lengthOf(0);
+      sinon.assert.calledOnce(getLabelsStub);
+      sinon.assert.calledOnceWithExactly(createLabelsStub, [
+        'autorelease: pending',
+        'autorelease: tagged',
+        'autorelease: pre-release',
+      ]);
     });
 
     it('reopens snoozed, closed pull request if there are changes', async () => {
@@ -4356,8 +4458,18 @@ describe('Manifest', () => {
       const removeLabelsStub = sandbox
         .stub(github, 'removeIssueLabels')
         .resolves();
+      const getLabelsStub = sandbox
+        .stub(github, 'getLabels')
+        .resolves(['label-a', 'label-b']);
+      const createLabelsStub = sandbox.stub(github, 'createLabels').resolves();
       const pullRequestNumbers = await manifest.createPullRequests();
       expect(pullRequestNumbers).lengthOf(1);
+      sinon.assert.calledOnce(getLabelsStub);
+      sinon.assert.calledOnceWithExactly(createLabelsStub, [
+        'autorelease: pending',
+        'autorelease: tagged',
+        'autorelease: pre-release',
+      ]);
       sinon.assert.calledOnce(removeLabelsStub);
     });
 
@@ -4425,8 +4537,18 @@ describe('Manifest', () => {
           draft: false,
         },
       ]);
+      const getLabelsStub = sandbox
+        .stub(github, 'getLabels')
+        .resolves(['label-a', 'label-b']);
+      const createLabelsStub = sandbox.stub(github, 'createLabels').resolves();
       const pullRequestNumbers = await manifest.createPullRequests();
       expect(pullRequestNumbers).lengthOf(0);
+      sinon.assert.calledOnce(getLabelsStub);
+      sinon.assert.calledOnceWithExactly(createLabelsStub, [
+        'autorelease: pending',
+        'autorelease: tagged',
+        'autorelease: pre-release',
+      ]);
     });
   });
 


### PR DESCRIPTION
This pull request adds a concept of "pre-release labels" that can be used on a release PR to denotate that the github release should be created as a pre-release. The label `autorelease: pre-release` is added directly by `release-please` when creating the PR if a pre-release is detected, but can also be added by users before merging the pull request.

In addition, to ensure labels can be selected by users via the "Labels dropdown" from GitHub UI, all labels are now created for the repository if they don't exist yet, before creating a pull request.