### PR TITLE
Fix bug where release-please is looking at extra files from target branch instead of the one where changes are located

### DIFF
--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -503,7 +503,7 @@ const createReleasePullRequestCommand: yargs.CommandModule<
         logger.debug('updates:', pullRequest.updates.length);
         const changes = await github.buildChangeSet(
           pullRequest.updates,
-          targetBranch
+          manifest.changesBranch
         );
         for (const update of pullRequest.updates) {
           logger.debug(

--- a/src/github.ts
+++ b/src/github.ts
@@ -1226,7 +1226,7 @@ export class GitHub {
       updates: Update[],
       options?: CreatePullRequestOptions
     ): Promise<PullRequest> => {
-      const changes = await this.buildChangeSet(updates, baseBranch);
+      const changes = await this.buildChangeSet(updates, refBranch);
 
       // create release branch
       const pullRequestBranchSha = await this.forkBranch(
@@ -1414,20 +1414,20 @@ export class GitHub {
    * Given a set of proposed updates, build a changeset to suggest.
    *
    * @param {Update[]} updates The proposed updates
-   * @param {string} baseBranch The branch to compare against
+   * @param {string} refBranch The branch where changed file are located
    * @return {Changes} The changeset to suggest.
    * @throws {GitHubAPIError} on an API error
    */
   async buildChangeSet(
     updates: Update[],
-    baseBranch: string
+    refBranch: string
   ): Promise<ChangeSet> {
     const changes = new Map();
     for (const update of updates) {
       let content: GitHubFileContents | undefined;
       this.logger.debug(`update.path: ${update.path}`);
       try {
-        content = await this.getFileContentsOnBranch(update.path, baseBranch);
+        content = await this.getFileContentsOnBranch(update.path, refBranch);
       } catch (err) {
         if (!(err instanceof FileNotFoundError)) throw err;
         // if the file is missing and create = false, just continue

--- a/src/github.ts
+++ b/src/github.ts
@@ -1080,20 +1080,6 @@ export class GitHub {
   }
 
   /**
-   * Fetch the contents of a file from the configured branch
-   *
-   * @param {string} path The path to the file in the repository
-   * @returns {GitHubFileContents}
-   * @throws {GitHubAPIError} on other API errors
-   */
-  async getFileContents(path: string): Promise<GitHubFileContents> {
-    return await this.getFileContentsOnBranch(
-      path,
-      this.repository.defaultBranch
-    );
-  }
-
-  /**
    * Fetch the contents of a file
    *
    * @param {string} path The path to the file in the repository
@@ -1129,28 +1115,6 @@ export class GitHub {
    * the provided prefix.
    *
    * @param filename The name of the file to find
-   * @param prefix Optional path prefix used to filter results
-   * @returns {string[]} List of file paths
-   * @throws {GitHubAPIError} on an API error
-   */
-  async findFilesByFilename(
-    filename: string,
-    prefix?: string
-  ): Promise<string[]> {
-    return this.findFilesByFilenameAndRef(
-      filename,
-      this.repository.defaultBranch,
-      prefix
-    );
-  }
-
-  /**
-   * Returns a list of paths to all files with a given name.
-   *
-   * If a prefix is specified, only return paths that match
-   * the provided prefix.
-   *
-   * @param filename The name of the file to find
    * @param ref Git reference to search files in
    * @param prefix Optional path prefix used to filter results
    * @throws {GitHubAPIError} on an API error
@@ -1171,24 +1135,6 @@ export class GitHub {
     }
   );
 
-  /**
-   * Returns a list of paths to all files matching a glob pattern.
-   *
-   * If a prefix is specified, only return paths that match
-   * the provided prefix.
-   *
-   * @param glob The glob to match
-   * @param prefix Optional path prefix used to filter results
-   * @returns {string[]} List of file paths
-   * @throws {GitHubAPIError} on an API error
-   */
-  async findFilesByGlob(glob: string, prefix?: string): Promise<string[]> {
-    return this.findFilesByGlobAndRef(
-      glob,
-      this.repository.defaultBranch,
-      prefix
-    );
-  }
   /**
    * Returns a list of paths to all files matching a glob pattern.
    *
@@ -1413,7 +1359,8 @@ export class GitHub {
       const body = (
         options?.pullRequestOverflowHandler
           ? await options.pullRequestOverflowHandler.handleOverflow(
-              releasePullRequest
+              releasePullRequest,
+              baseBranch
             )
           : releasePullRequest.body
       )
@@ -1534,30 +1481,6 @@ export class GitHub {
       return this.fileCache.findFilesByExtension(extension, ref, prefix);
     }
   );
-
-  /**
-   * Returns a list of paths to all files with a given file
-   * extension.
-   *
-   * If a prefix is specified, only return paths that match
-   * the provided prefix.
-   *
-   * @param extension The file extension used to filter results.
-   *   Example: `js`, `java`
-   * @param prefix Optional path prefix used to filter results
-   * @returns {string[]} List of file paths
-   * @throws {GitHubAPIError} on an API error
-   */
-  async findFilesByExtension(
-    extension: string,
-    prefix?: string
-  ): Promise<string[]> {
-    return this.findFilesByExtensionAndRef(
-      extension,
-      this.repository.defaultBranch,
-      prefix
-    );
-  }
 
   /**
    * Create a GitHub release

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -961,7 +961,8 @@ export class Manifest {
     }
 
     const body = await this.pullRequestOverflowHandler.handleOverflow(
-      pullRequest
+      pullRequest,
+      this.changesBranch
     );
     const message = this.signoffUser
       ? signoffCommitMessage(pullRequest.title.toString(), this.signoffUser)

--- a/src/strategies/helm.ts
+++ b/src/strategies/helm.ts
@@ -65,8 +65,9 @@ export class Helm extends BaseStrategy {
   private async getChartYmlContents(): Promise<GitHubFileContents> {
     if (!this.chartYmlContents) {
       try {
-        this.chartYmlContents = await this.github.getFileContents(
-          this.addPath('Chart.yaml')
+        this.chartYmlContents = await this.github.getFileContentsOnBranch(
+          this.addPath('Chart.yaml'),
+          this.changesBranch
         );
       } catch (e) {
         if (e instanceof FileNotFoundError) {

--- a/src/strategies/krm-blueprint.ts
+++ b/src/strategies/krm-blueprint.ts
@@ -54,9 +54,11 @@ export class KRMBlueprint extends BaseStrategy {
       this.path
     );
     for (const yamlPath of yamlPaths) {
-      const contents: GitHubFileContents = await this.github.getFileContents(
-        this.addPath(yamlPath)
-      );
+      const contents: GitHubFileContents =
+        await this.github.getFileContentsOnBranch(
+          this.addPath(yamlPath),
+          this.changesBranch
+        );
       if (hasKRMBlueprintAttrib(contents.parsedContent)) {
         updates.push({
           path: this.addPath(yamlPath),

--- a/src/strategies/ocaml.ts
+++ b/src/strategies/ocaml.ts
@@ -41,12 +41,18 @@ export class OCaml extends BaseStrategy {
       }),
     });
 
-    const jsonPaths = await this.github.findFilesByExtension('json', this.path);
+    const jsonPaths = await this.github.findFilesByExtensionAndRef(
+      'json',
+      this.changesBranch,
+      this.path
+    );
     for (const path of jsonPaths) {
       if (notEsyLock(path)) {
-        const contents: GitHubFileContents = await this.github.getFileContents(
-          this.addPath(path)
-        );
+        const contents: GitHubFileContents =
+          await this.github.getFileContentsOnBranch(
+            this.addPath(path),
+            this.changesBranch
+          );
         const pkg = JSON.parse(contents.parsedContent);
         if (pkg.version !== undefined) {
           updates.push({
@@ -61,7 +67,11 @@ export class OCaml extends BaseStrategy {
       }
     }
 
-    const opamPaths = await this.github.findFilesByExtension('opam', this.path);
+    const opamPaths = await this.github.findFilesByExtensionAndRef(
+      'opam',
+      this.changesBranch,
+      this.path
+    );
     opamPaths.filter(notEsyLock).forEach(path => {
       updates.push({
         path: this.addPath(path),
@@ -72,8 +82,9 @@ export class OCaml extends BaseStrategy {
       });
     });
 
-    const opamLockedPaths = await this.github.findFilesByExtension(
+    const opamLockedPaths = await this.github.findFilesByExtensionAndRef(
       'opam.locked',
+      this.changesBranch,
       this.path
     );
     opamLockedPaths.filter(notEsyLock).forEach(path => {

--- a/src/util/pull-request-overflow-handler.ts
+++ b/src/util/pull-request-overflow-handler.ts
@@ -37,11 +37,13 @@ export interface PullRequestOverflowHandler {
    * If a pull request's body is too big, store it somewhere and return
    * a new pull request body with information about the new location.
    * @param {ReleasePullRequest} pullRequest The candidate release pull request
+   * @param {string} baseBranch The branch to use as the base branch to fork from
    * @returns {string} The new pull request body which may contain a link to
    *   the full content.
    */
   handleOverflow(
     pullRequest: ReleasePullRequest,
+    baseBranch: string,
     maxSize?: number
   ): Promise<string>;
 
@@ -81,6 +83,7 @@ export class FilePullRequestOverflowHandler
    */
   async handleOverflow(
     pullRequest: ReleasePullRequest,
+    baseBranch: string,
     maxSize: number = MAX_ISSUE_BODY_SIZE
   ): Promise<string> {
     const notes = pullRequest.body.toString();
@@ -90,7 +93,7 @@ export class FilePullRequestOverflowHandler
         RELEASE_NOTES_FILENAME,
         notes,
         notesBranchName,
-        this.github.repository.defaultBranch
+        baseBranch
       );
       return `${OVERFLOW_MESSAGE} ${url}`;
     }

--- a/test/github.ts
+++ b/test/github.ts
@@ -137,7 +137,10 @@ describe('GitHub', () => {
       req
         .get('/repos/fake/fake/git/trees/main?recursive=true')
         .reply(200, fileSearchResponse);
-      const pomFiles = await github.findFilesByFilename('pom.xml');
+      const pomFiles = await github.findFilesByFilenameAndRef(
+        'pom.xml',
+        'main'
+      );
       snapshot(pomFiles);
       req.done();
     });
@@ -162,7 +165,11 @@ describe('GitHub', () => {
         req
           .get('/repos/fake/fake/git/trees/main?recursive=true')
           .reply(200, fileSearchResponse);
-        const pomFiles = await github.findFilesByFilename('pom.xml', prefix);
+        const pomFiles = await github.findFilesByFilenameAndRef(
+          'pom.xml',
+          'main',
+          prefix
+        );
         req.done();
         expect(pomFiles).to.deep.equal(['pom.xml', 'foo/pom.xml']);
       });
@@ -177,7 +184,7 @@ describe('GitHub', () => {
       req
         .get('/repos/fake/fake/git/trees/main?recursive=true')
         .reply(200, fileSearchResponse);
-      const pomFiles = await github.findFilesByExtension('xml');
+      const pomFiles = await github.findFilesByExtensionAndRef('xml', 'main');
       snapshot(pomFiles);
       req.done();
     });
@@ -202,7 +209,11 @@ describe('GitHub', () => {
         req
           .get('/repos/fake/fake/git/trees/main?recursive=true')
           .reply(200, fileSearchResponse);
-        const pomFiles = await github.findFilesByExtension('xml', prefix);
+        const pomFiles = await github.findFilesByExtensionAndRef(
+          'xml',
+          'main',
+          prefix
+        );
         req.done();
         expect(pomFiles).to.deep.equal(['pom.xml', 'foo/pom.xml']);
       });
@@ -217,7 +228,11 @@ describe('GitHub', () => {
       req
         .get('/repos/fake/fake/git/trees/main?recursive=true')
         .reply(200, fileSearchResponse);
-      const pomFiles = await github.findFilesByExtension('xml', 'appengine');
+      const pomFiles = await github.findFilesByExtensionAndRef(
+        'xml',
+        'main',
+        'appengine'
+      );
       req.done();
       expect(pomFiles).to.deep.equal(['pom.xml', 'foo/pom.xml']);
     });
@@ -257,7 +272,10 @@ describe('GitHub', () => {
         )
         .reply(200, dataAPIBlobResponse);
 
-      const fileContents = await github.getFileContents('package-lock.json');
+      const fileContents = await github.getFileContentsOnBranch(
+        'package-lock.json',
+        'main'
+      );
       expect(fileContents).to.have.property('content');
       expect(fileContents).to.have.property('parsedContent');
       expect(fileContents)
@@ -269,7 +287,7 @@ describe('GitHub', () => {
 
     it('should throw a missing file error', async () => {
       await assert.rejects(async () => {
-        await github.getFileContents('non-existent-file');
+        await github.getFileContentsOnBranch('non-existent-file', 'main');
       }, FileNotFoundError);
     });
   });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -133,7 +133,7 @@ export interface StubFiles {
   sandbox: sinon.SinonSandbox;
   github: GitHub;
 
-  // "master" TODO update all test code to use "main"
+  // "main"
   targetBranch?: string;
 
   // Example1: test/updaters/fixtures/python
@@ -175,7 +175,7 @@ export function stubFilesFromFixtures(options: StubFiles) {
       'Overlap between files and inlineFiles: ' + JSON.stringify(overlap)
     );
   }
-  const targetBranch = options.targetBranch ?? 'master';
+  const targetBranch = options.targetBranch ?? 'main';
   const flatten = options.flatten ?? true;
   const stub = sandbox.stub(github, 'getFileContentsOnBranch');
   for (const file of files) {
@@ -396,6 +396,7 @@ export class MockPullRequestOverflowHandler
 {
   async handleOverflow(
     pullRequest: ReleasePullRequest,
+    _baseBranch: string,
     _maxSize?: number | undefined
   ): Promise<string> {
     return pullRequest.body.toString();

--- a/test/plugins/maven-workspace.ts
+++ b/test/plugins/maven-workspace.ts
@@ -402,7 +402,7 @@ describe('MavenWorkspace plugin', () => {
         'bom/pom.xml',
         PomXml
       );
-      safeSnapshot(await renderUpdate(github, bomUpdate));
+      safeSnapshot(await renderUpdate(github, 'main', bomUpdate));
     });
     it('skips updating manifest with snapshot versions', async () => {
       plugin = new MavenWorkspace(github, 'main', {
@@ -515,8 +515,13 @@ function buildMockPackageUpdate(
   };
 }
 
-async function renderUpdate(github: GitHub, update: Update): Promise<string> {
+async function renderUpdate(
+  github: GitHub,
+  branch: string,
+  update: Update
+): Promise<string> {
   const fileContents =
-    update.cachedFileContents || (await github.getFileContents(update.path));
+    update.cachedFileContents ||
+    (await github.getFileContentsOnBranch(update.path, branch));
   return update.updater.updateContent(fileContents.parsedContent);
 }

--- a/test/strategies/base.ts
+++ b/test/strategies/base.ts
@@ -94,7 +94,15 @@ describe('Strategy', () => {
         targetBranch: 'main',
         github,
         component: 'google-cloud-automl',
-        extraFiles: ['0', 'foo/1.~csv', 'foo/2.bak', 'foo/baz/bar/', '/3.java'],
+        extraFiles: [
+          'README.md',
+          'build.gradle.kts',
+          '0',
+          'foo/1.~csv',
+          'foo/2.bak',
+          'foo/baz/bar/',
+          '/3.java',
+        ],
       });
       const pullRequest = await strategy.buildReleasePullRequest(
         buildMockConventionalCommit('fix: a bugfix'),
@@ -104,6 +112,8 @@ describe('Strategy', () => {
       expect(pullRequest?.updates).to.be.an('array');
       expect(pullRequest?.updates.map(update => update.path))
         .to.include.members([
+          'README.md',
+          'build.gradle.kts',
           '0',
           '3.java',
           'foo/1.~csv',

--- a/test/strategies/ocaml.ts
+++ b/test/strategies/ocaml.ts
@@ -63,7 +63,7 @@ describe('OCaml', () => {
         github,
         component: 'google-cloud-automl',
       });
-      sandbox.stub(github, 'findFilesByExtension').resolves([]);
+      sandbox.stub(github, 'findFilesByExtensionAndRef').resolves([]);
       const latestRelease = undefined;
       const release = await strategy.buildReleasePullRequest(
         COMMITS,
@@ -78,7 +78,7 @@ describe('OCaml', () => {
         github,
         component: 'google-cloud-automl',
       });
-      sandbox.stub(github, 'findFilesByExtension').resolves([]);
+      sandbox.stub(github, 'findFilesByExtensionAndRef').resolves([]);
       const latestRelease = {
         tag: new TagName(Version.parse('0.123.4'), 'google-cloud-automl'),
         sha: 'abc123',
@@ -98,7 +98,7 @@ describe('OCaml', () => {
         github,
         component: 'google-cloud-automl',
       });
-      sandbox.stub(github, 'findFilesByExtension').resolves([]);
+      sandbox.stub(github, 'findFilesByExtensionAndRef').resolves([]);
       const latestRelease = undefined;
       const release = await strategy.buildReleasePullRequest(
         COMMITS,
@@ -116,11 +116,13 @@ describe('OCaml', () => {
         github,
         component: 'google-cloud-automl',
       });
-      const findFilesStub = sandbox.stub(github, 'findFilesByExtension');
-      findFilesStub.withArgs('json', '.').resolves(['esy.json', 'other.json']);
-      findFilesStub.withArgs('opam', '.').resolves(['sample.opam']);
+      const findFilesStub = sandbox.stub(github, 'findFilesByExtensionAndRef');
       findFilesStub
-        .withArgs('opam.locked', '.')
+        .withArgs('json', 'main', '.')
+        .resolves(['esy.json', 'other.json']);
+      findFilesStub.withArgs('opam', 'main', '.').resolves(['sample.opam']);
+      findFilesStub
+        .withArgs('opam.locked', 'main', '.')
         .resolves(['sample.opam.locked']);
       stubFilesFromFixtures({
         sandbox,

--- a/test/util/pull-request-overflow-handler.ts
+++ b/test/util/pull-request-overflow-handler.ts
@@ -62,27 +62,31 @@ describe('FilePullRequestOverflowHandler', () => {
         );
       const newContents = await overflowHandler.handleOverflow(
         {
-          title: PullRequestTitle.ofTargetBranch('main', 'main'),
+          title: PullRequestTitle.ofTargetBranch('main', 'next'),
           body,
           labels: [],
           updates: [],
           draft: false,
           headRefName: 'my-head-branch',
         },
+        'next',
         50
       );
       snapshot(newContents);
       sinon.assert.calledOnce(createFileStub);
     });
     it('ignores small pull request body contents', async () => {
-      const newContents = await overflowHandler.handleOverflow({
-        title: PullRequestTitle.ofTargetBranch('main', 'main'),
-        body,
-        labels: [],
-        updates: [],
-        draft: false,
-        headRefName: 'my-head-branch',
-      });
+      const newContents = await overflowHandler.handleOverflow(
+        {
+          title: PullRequestTitle.ofTargetBranch('main', 'next'),
+          body,
+          labels: [],
+          updates: [],
+          draft: false,
+          headRefName: 'my-head-branch',
+        },
+        'next'
+      );
       expect(newContents).to.eql(body.toString());
     });
   });


### PR DESCRIPTION
Looking at the diff at https://github.com/stainless-sdks/sink-kotlin-public/pull/59/commits/a62d9a1df3030a35e27d6f3949afd951f2dd7010#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5 it seems that we aren't comparing against the correct branch when creating the changelog commit as part of a release PR. That means that any changes from `extra-files` (i.e a release-please config key specifying extra files to update) are reversed.