### PR TITLE
Create releases even if release branch not in sync with change-branch

### DIFF
--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -6243,7 +6243,7 @@ describe('Manifest', () => {
       sinon.assert.calledOnce(unlockBranchStub);
     });
 
-    it('should fallback to checking twice for race conditions when branch lock fails due to missing token permissions (REST error)', async () => {
+    it('should use fallback when branch lock fails due to missing token permissions (REST error)', async () => {
       mockPullRequests(
         github,
         [],
@@ -6320,7 +6320,7 @@ describe('Manifest', () => {
         }
       );
 
-      // stub the race condition detection method to be able to check it was called twice
+      // stub the race condition detection method to be able to check it was called once
       const throwIfChangesBranchesRaceConditionDetectedStub = sandbox.stub(
         manifest,
         <any>'throwIfChangesBranchesRaceConditionDetected' // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -6345,12 +6345,12 @@ describe('Manifest', () => {
         1234
       );
 
-      sinon.assert.calledTwice(throwIfChangesBranchesRaceConditionDetectedStub);
+      sinon.assert.called(throwIfChangesBranchesRaceConditionDetectedStub);
       // ensure we don't try to update permissions rules again given the lock failed
       sinon.assert.notCalled(unlockBranchStub);
     });
 
-    it('should fallback to checking twice for race conditions when branch lock fails due to missing token permissions (GraphQL error)', async () => {
+    it('should use fallback when branch lock fails due to missing token permissions (GraphQL error)', async () => {
       mockPullRequests(
         github,
         [],
@@ -6429,7 +6429,7 @@ describe('Manifest', () => {
         }
       );
 
-      // stub the race condition detection method to be able to check it was called twice
+      // stub the race condition detection method to be able to check it was called once
       const throwIfChangesBranchesRaceConditionDetectedStub = sandbox.stub(
         manifest,
         <any>'throwIfChangesBranchesRaceConditionDetected' // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -6454,7 +6454,7 @@ describe('Manifest', () => {
         1234
       );
 
-      sinon.assert.calledTwice(throwIfChangesBranchesRaceConditionDetectedStub);
+      sinon.assert.calledOnce(throwIfChangesBranchesRaceConditionDetectedStub);
       // ensure we don't try to update permissions rules again given the lock failed
       sinon.assert.notCalled(unlockBranchStub);
     });


### PR DESCRIPTION
This Pull Request changes the logic when creating releases. Instead of trying to look early for inconsistencies between branches `next` and `release-please--branches--main--changes--next` and failing the whole process, we now first create releases and only check for inconsistencies before re-aligning `next` with `main`.

That way in case of issues when comparing branches, or if we found inconsistencies, we do not block the entire release process but will still result in a failed run, which should log an error when run from Stainless's API. That should provide a better end-user experience.