### PR TITLE
Improve branch re-alignment logic: rely on PR commits instead of PR branch, ensure we only align when safe to do so, and more

### DIFF
--- a/__snapshots__/manifest.js
+++ b/__snapshots__/manifest.js
@@ -163,3 +163,5 @@ For a better experience, it is recommended to use either rebase-merge or squash-
 
 _More technical details can be found at [stainless-api/release-please](https://github.com/stainless-api/release-please)_.
 `
+
+exports['Manifest createReleases should throw when release branch is missing and changes-branch not in synced with target-branch 1'] = {}

--- a/__snapshots__/manifest.js
+++ b/__snapshots__/manifest.js
@@ -165,5 +165,5 @@ _More technical details can be found at [stainless-api/release-please](https://g
 `
 
 exports['Manifest createReleases should throw when release branch is missing and changes-branch not in synced with target-branch 1'] = `
-Branch 'next' cannot be safely re-aligned with 'main', and will likely result in git conflicts when the next release PR is created. Hint: compare release-please--branches--main--changes--next, next, and main for inconsistencies
+Branch 'next' cannot be safely re-aligned with 'main', and will likely result in git conflicts when the next release PR is created. Hint: compare branches 'release-please--branches--main--changes--next', 'next', and 'main' for inconsistencies
 `

--- a/__snapshots__/manifest.js
+++ b/__snapshots__/manifest.js
@@ -164,4 +164,6 @@ For a better experience, it is recommended to use either rebase-merge or squash-
 _More technical details can be found at [stainless-api/release-please](https://github.com/stainless-api/release-please)_.
 `
 
-exports['Manifest createReleases should throw when release branch is missing and changes-branch not in synced with target-branch 1'] = {}
+exports['Manifest createReleases should throw when release branch is missing and changes-branch not in synced with target-branch 1'] = `
+Branch 'next' cannot be safely re-aligned with 'main', and will likely result in git conflicts when the next release PR is created. Hint: compare release-please--branches--main--changes--next, next, and main for inconsistencies
+`

--- a/src/github.ts
+++ b/src/github.ts
@@ -1930,16 +1930,13 @@ export class GitHub {
     }
 
     const commitsPerPage = 100;
-    const lastPageOfPrCommits = await this.request(
-      'GET /repos/{owner}/{repo}/pulls/{pull_number}/commits',
-      {
-        pull_number: pullRequest.number,
-        owner: this.repository.owner,
-        repo: this.repository.repo,
-        per_page: commitsPerPage,
-        page: Math.ceil(pr.data.commits / commitsPerPage),
-      }
-    );
+    const lastPageOfPrCommits = await this.octokit.pulls.listCommits({
+      pull_number: pullRequest.number,
+      owner: this.repository.owner,
+      repo: this.repository.repo,
+      per_page: commitsPerPage,
+      page: Math.ceil(pr.data.commits / commitsPerPage),
+    });
 
     const latestPRCommit =
       lastPageOfPrCommits.data[lastPageOfPrCommits.data.length - 1];

--- a/src/github.ts
+++ b/src/github.ts
@@ -1958,7 +1958,7 @@ export class GitHub {
     }
 
     if (comparison.data.status === 'diverged') {
-      // For each branch fetch commits since the last known common sha
+      // For each branch fetch commits since branches diverged
       const exclusiveCommitsA = new Set(
         comparison.data.commits.map(commit => commit.sha)
       );

--- a/src/github.ts
+++ b/src/github.ts
@@ -1992,6 +1992,11 @@ export class GitHub {
         ).data.commits.map(commit => commit.sha)
       );
 
+      // if branch A has more commits than branch B, we know for sure they aren't in sync
+      if (exclusiveCommitsA.size > exclusiveCommitsB.size) {
+        return false;
+      }
+
       type CommitData = Awaited<
         ReturnType<typeof this.octokit.repos.getCommit>
       >['data'];

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1269,31 +1269,32 @@ export class Manifest {
         continue;
       }
       this.logger.info(
-        `Aligning pull request branches for PR #${pr.number}, changes branch ${branchName.changesBranch} to be aligned with ${this.targetBranch}`
+        `Aligning branches for PR #${pr.number}, changes branch ${branchName.changesBranch} to be aligned with ${this.targetBranch}`
       );
 
       let safeToRealign = false;
 
-      // first check if the release branch is synced with changes-branch
       try {
         this.logger.debug(
-          `Checking if ${pr.headBranchName} is synced with ${branchName.changesBranch}...`
+          `Checking if PR commits are in sync with ${branchName.changesBranch}...`
         );
         if (
-          await this.github.isBranchASyncedWithB(
-            pr.headBranchName,
-            branchName.changesBranch
+          await this.github.isBranchSyncedWithPullRequestCommits(
+            branchName.changesBranch,
+            pr
           )
         ) {
-          this.logger.debug('Branches in sync, safe to re-align');
+          this.logger.debug(
+            'PR commits and changes branch in sync, safe to re-align'
+          );
           safeToRealign = true;
         }
       } catch (err: unknown) {
-        // if a branch is not found, it is likely that the release branch has been deleted. In this case just ignore and
-        // continue with the next check
+        // if a branch of commit cannot be found it is likely the PR commits information aren't in a reliable state, in
+        // this case just ignore and continue with the next check
         if (isOctokitRequestError(err) && err.status === 404) {
           this.logger.debug(
-            `Could not compare branches '${pr.headBranchName}' and '${branchName.changesBranch}' due to a missing branch. Continue with the next check`
+            `Could not compare commits from PR and '${branchName.changesBranch}' due to a branch or commit not found. Continue with the next check`
           );
         } else {
           throw err;

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1318,7 +1318,7 @@ export class Manifest {
 
       if (!safeToRealign) {
         throw new Error(
-          `Branch '${branchName.changesBranch}' cannot be safely re-aligned with '${this.targetBranch}', and will likely result in git conflicts when the next release PR is created. Hint: compare ${pr.headBranchName}, ${branchName.changesBranch}, and ${this.targetBranch} for inconsistencies`
+          `Branch '${branchName.changesBranch}' cannot be safely re-aligned with '${this.targetBranch}', and will likely result in git conflicts when the next release PR is created. Hint: compare branches '${pr.headBranchName}', '${branchName.changesBranch}', and '${this.targetBranch}' for inconsistencies`
         );
       }
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1276,7 +1276,7 @@ export class Manifest {
 
       try {
         this.logger.debug(
-          `Checking if PR commits are in sync with ${branchName.changesBranch}...`
+          `Checking if PR commits are in sync with '${branchName.changesBranch}'...`
         );
         if (
           await this.github.isBranchSyncedWithPullRequestCommits(

--- a/test/changelog-notes/github-changelog-notes.ts
+++ b/test/changelog-notes/github-changelog-notes.ts
@@ -70,6 +70,7 @@ describe('GitHubChangelogNotes', () => {
       changesBranch: 'main',
     };
     let github: GitHub;
+    let req: nock.Scope;
     beforeEach(async () => {
       github = await GitHub.create({
         owner: 'fake-owner',
@@ -77,7 +78,7 @@ describe('GitHubChangelogNotes', () => {
         defaultBranch: 'main',
         token: 'fake-token',
       });
-      nock('https://api.github.com/')
+      req = nock('https://api.github.com/')
         .post('/repos/fake-owner/fake-repo/releases/generate-notes')
         .reply(200, {
           name: 'Release v1.0.0 is now available!',
@@ -89,6 +90,7 @@ describe('GitHubChangelogNotes', () => {
       const notes = await changelogNotes.buildNotes(commits, notesOptions);
       expect(notes).to.is.string;
       safeSnapshot(notes);
+      req.done();
     });
 
     it('should build parseable notes', async () => {
@@ -118,6 +120,7 @@ describe('GitHubChangelogNotes', () => {
       expect(parsedPullRequestBody!.releaseData[0].version?.toString()).to.eql(
         '1.2.3'
       );
+      req.done();
     });
   });
 });

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -6960,7 +6960,7 @@ describe('Manifest', () => {
         err = e;
       }
       expect(err).to.be.instanceOf(Error);
-      snapshot(<Error>err);
+      snapshot((<Error>err).message);
 
       // releases are still created
       sinon.assert.calledOnce(commentStub);

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -6690,14 +6690,16 @@ describe('Manifest', () => {
       const lockBranchStub = sandbox.stub(github, 'lockBranch').resolves();
       const unlockBranchStub = sandbox.stub(github, 'unlockBranch').resolves();
 
-      const isBranchASyncedWithBStub = sandbox.stub(
-        github,
-        'isBranchASyncedWithB'
-      );
-
       // release branch in synced with changes-branch, safe to align changes-branch with target-branch
-      isBranchASyncedWithBStub
-        .withArgs('release-please--branches--main--changes--next', 'next')
+      const isBranchSyncedWithPullRequestCommitsStub = sandbox
+        .stub(github, 'isBranchSyncedWithPullRequestCommits')
+        .withArgs(
+          'next',
+          sinon.match.has(
+            'headBranchName',
+            'release-please--branches--main--changes--next'
+          )
+        )
         .resolves(true);
 
       const alignBranchWithAnotherStub = sandbox
@@ -6736,7 +6738,7 @@ describe('Manifest', () => {
         1234
       );
 
-      sinon.assert.calledOnce(isBranchASyncedWithBStub);
+      sinon.assert.calledOnce(isBranchSyncedWithPullRequestCommitsStub);
       sinon.assert.calledOnce(alignBranchWithAnotherStub);
 
       sinon.assert.calledOnce(lockBranchStub);
@@ -6782,14 +6784,16 @@ describe('Manifest', () => {
       const lockBranchStub = sandbox.stub(github, 'lockBranch').resolves();
       const unlockBranchStub = sandbox.stub(github, 'unlockBranch').resolves();
 
-      const isBranchASyncedWithBStub = sandbox.stub(
-        github,
-        'isBranchASyncedWithB'
-      );
-
-      // throw 404 not found when comparing changes-branch against release branch
-      isBranchASyncedWithBStub
-        .withArgs('release-please--branches--main--changes--next', 'next')
+      // throw 404 not found when comparing changes-branch against pull request commits
+      const isBranchSyncedWithPullRequestCommitsStub = sandbox
+        .stub(github, 'isBranchSyncedWithPullRequestCommits')
+        .withArgs(
+          'next',
+          sinon.match.has(
+            'headBranchName',
+            'release-please--branches--main--changes--next'
+          )
+        )
         .throwsException(
           new RequestError('Resource not found', 404, {
             request: {
@@ -6816,7 +6820,10 @@ describe('Manifest', () => {
         );
 
       // changes-branch already synced with target-branch
-      isBranchASyncedWithBStub.withArgs('next', 'main').resolves(true);
+      const isBranchASyncedWithBStub = sandbox
+        .stub(github, 'isBranchASyncedWithB')
+        .withArgs('next', 'main')
+        .resolves(true);
 
       const alignBranchWithAnotherStub = sandbox
         .stub(github, 'alignBranchWithAnother')
@@ -6854,7 +6861,8 @@ describe('Manifest', () => {
         1234
       );
 
-      sinon.assert.calledTwice(isBranchASyncedWithBStub);
+      sinon.assert.calledOnce(isBranchSyncedWithPullRequestCommitsStub);
+      sinon.assert.calledOnce(isBranchASyncedWithBStub);
       sinon.assert.notCalled(alignBranchWithAnotherStub);
 
       sinon.assert.calledOnce(lockBranchStub);
@@ -6900,14 +6908,16 @@ describe('Manifest', () => {
       const lockBranchStub = sandbox.stub(github, 'lockBranch').resolves();
       const unlockBranchStub = sandbox.stub(github, 'unlockBranch').resolves();
 
-      const isBranchASyncedWithBStub = sandbox.stub(
-        github,
-        'isBranchASyncedWithB'
-      );
-
       // throw 404 not found when comparing changes-branch against release branch
-      isBranchASyncedWithBStub
-        .withArgs('release-please--branches--main--changes--next', 'next')
+      const isBranchSyncedWithPullRequestCommitsStub = sandbox
+        .stub(github, 'isBranchSyncedWithPullRequestCommits')
+        .withArgs(
+          'next',
+          sinon.match.has(
+            'headBranchName',
+            'release-please--branches--main--changes--next'
+          )
+        )
         .throwsException(
           new RequestError('Resource not found', 404, {
             request: {
@@ -6934,7 +6944,10 @@ describe('Manifest', () => {
         );
 
       // changes-branch not in synced with target-branch
-      isBranchASyncedWithBStub.withArgs('next', 'main').resolves(false);
+      const isBranchASyncedWithBStub = sandbox
+        .stub(github, 'isBranchASyncedWithB')
+        .withArgs('next', 'main')
+        .resolves(false);
 
       const alignBranchWithAnotherStub = sandbox
         .stub(github, 'alignBranchWithAnother')
@@ -6975,7 +6988,8 @@ describe('Manifest', () => {
         1234
       );
 
-      sinon.assert.calledTwice(isBranchASyncedWithBStub);
+      sinon.assert.calledOnce(isBranchSyncedWithPullRequestCommitsStub);
+      sinon.assert.calledOnce(isBranchASyncedWithBStub);
       sinon.assert.notCalled(alignBranchWithAnotherStub);
 
       sinon.assert.calledOnce(lockBranchStub);


### PR DESCRIPTION
This pull request cleans up the branch branch alignment logic.

Notes:
- `throwIfChangesBranchesRaceConditionDetected` removed as it isn't needed anymore
- `isBranchASyncedWithB` has been rewritten and now uses way smarter heuristics to determine if branches are in sync:
  - when branches are diverging, gather all their commits since their last common commit and compare their content one by one to identify if they are similar. If all commits from A are found to be similar to commits from B, we are in sync, otherwise we aren't.
- a new method `isBranchSyncedWithPullRequestCommits` can identify if a branch (`next`) is in sync with a PR (commits from the PR itself, **not the PR branch**!), that makes it possible to handle any type of merge strategy and works even if the release branch has been deleted 🎉
- if `next` and the PR aren't in sync, then check if `next` and `main` have already been synced
- if for any reason a 404 is returned by github when comparing `next` and commits from the PR (may be caused by by git's garbage collection, or anything else), then as a last option just compare `next` and `main`
 
The re-alignment logic should be simpler to follow and its behaviour way more robust than before!

In addition I added test coverage for the different situations we've seen so far and improved errors reporting.

With those change there are three main situations where we would throw an error after creating releases:
1. `next` and the release branch are found to not be aligned, and `next` and `main` are not in sync
2. `next` and the release branch cannot be checked due to a deleted branch, and `next` and `main` are not in sync
3. an error other than a 404 is returned by github when comparing branches

Other cases should either result in nothing being done (because `next` and `main` are already in sync), or `next` and `main` being re-aligned.

