### PR TITLE
Use version from PR title when edited by end user

### DIFF
--- a/__snapshots__/manifest.js
+++ b/__snapshots__/manifest.js
@@ -185,3 +185,13 @@ The Pull Request version has been manually set to \`4.5.6-beta.1\` and will be u
 If you instead want to use the version number \`0.2.4\` generated from conventional commits, just remove the label \`autorelease: custom version\` from this Pull Request.
 
 `
+
+exports['Manifest buildPullRequests should warn end user via PR comment if version not found in title and not labeled as custom version 1'] = `
+
+## Invalid version number in PR title
+
+:warning: No version number can be found in the title. Did you want to set a custom version for this release?
+
+To set a custom version be sure to use the semver format, e.g \`1.2.3\`.
+
+`

--- a/__snapshots__/manifest.js
+++ b/__snapshots__/manifest.js
@@ -225,3 +225,7 @@ exports['Manifest buildPullRequests should warn end user via PR comment if versi
 To set a custom version be sure to use the [semantic versioning format](https://devhints.io/semver), e.g \`1.2.3\`.
 
 `
+
+exports['Manifest createReleases should throw when release branch is missing and changes-branch not in synced with target-branch 1'] = `
+Branch 'next' cannot be safely re-aligned with 'main', and will likely result in git conflicts when the next release PR is created. Hint: compare branches 'release-please--branches--main--changes--next', 'next', and 'main' for inconsistencies
+`

--- a/__snapshots__/manifest.js
+++ b/__snapshots__/manifest.js
@@ -180,9 +180,39 @@ exports['Manifest buildPullRequests should use version from existing PR title if
 
 ## Release version edited manually
 
-The Pull Request version has been manually set to \`4.5.6-beta.1\` and will be used for the release.
+The Pull Request version has been manually set to \`6.7.9-alpha.1\` and will be used for the release.
 
-If you instead want to use the version number \`0.2.4\` generated from conventional commits, just remove the label \`autorelease: custom version\` from this Pull Request.
+If you instead want to use the version number \`1.0.1\` generated from conventional commits, just remove the label \`autorelease: custom version\` from this Pull Request.
+
+`
+
+exports['Manifest buildPullRequests should use version from existing PR title if differs from release branch manifest 2'] = `
+
+## Release version edited manually
+
+The Pull Request version has been manually set to \`7.8.9\` and will be used for the release.
+
+If you instead want to use the version number \`2.0.1\` generated from conventional commits, just remove the label \`autorelease: custom version\` from this Pull Request.
+
+`
+
+exports['Manifest buildPullRequests should use version from existing PR title if differs from release branch manifest 3'] = `
+
+## Release version edited manually
+
+The Pull Request version has been manually set to \`8.9.0\` and will be used for the release.
+
+If you instead want to use the version number \`3.0.1\` generated from conventional commits, just remove the label \`autorelease: custom version\` from this Pull Request.
+
+`
+
+exports['Manifest buildPullRequests should use version from existing PR title if differs from release branch manifest 4'] = `
+
+## Release version edited manually
+
+The Pull Request version has been manually set to \`9.0.1\` and will be used for the release.
+
+If you instead want to use the version number \`4.0.1\` generated from conventional commits, just remove the label \`autorelease: custom version\` from this Pull Request.
 
 `
 

--- a/__snapshots__/manifest.js
+++ b/__snapshots__/manifest.js
@@ -170,7 +170,7 @@ exports['Manifest buildPullRequests should report issue via PR comment if labele
 
 :rotating_light: This Pull Request has the \`autorelease: custom version\` label but the version number cannot be found in the title. Instead the generated version \`0.2.4\` will be used.
 
-If you want to use a custom version be sure to use the semver format.
+If you want to set a custom version be sure to use the [semantic versioning format](https://devhints.io/semver).
 
 If you do not want to set a custom version and want  to get rid of this warning, remove the label \`autorelease: custom version\` from this Pull Request.
 

--- a/__snapshots__/manifest.js
+++ b/__snapshots__/manifest.js
@@ -170,7 +170,7 @@ exports['Manifest buildPullRequests should report issue via PR comment if labele
 
 :rotating_light: This Pull Request has the \`autorelease: custom version\` label but the version number cannot be found in the title. Instead the generated version \`0.2.4\` will be used.
 
-If you want to set a custom version be sure to use the [semantic versioning format](https://devhints.io/semver).
+If you want to set a custom version be sure to use the [semantic versioning format](https://devhints.io/semver), e.g \`1.2.3\`.
 
 If you do not want to set a custom version and want  to get rid of this warning, remove the label \`autorelease: custom version\` from this Pull Request.
 
@@ -220,8 +220,8 @@ exports['Manifest buildPullRequests should warn end user via PR comment if versi
 
 ## Invalid version number in PR title
 
-:warning: No version number can be found in the title. Did you want to set a custom version for this release?
+:warning: No version number can be found in the title, the generated version \`0.2.4\` will be used. Did you want to change the version for this release?
 
-To set a custom version be sure to use the semver format, e.g \`1.2.3\`.
+To set a custom version be sure to use the [semantic versioning format](https://devhints.io/semver), e.g \`1.2.3\`.
 
 `

--- a/__snapshots__/manifest.js
+++ b/__snapshots__/manifest.js
@@ -164,6 +164,24 @@ For a better experience, it is recommended to use either rebase-merge or squash-
 _More technical details can be found at [stainless-api/release-please](https://github.com/stainless-api/release-please)_.
 `
 
-exports['Manifest createReleases should throw when release branch is missing and changes-branch not in synced with target-branch 1'] = `
-Branch 'next' cannot be safely re-aligned with 'main', and will likely result in git conflicts when the next release PR is created. Hint: compare branches 'release-please--branches--main--changes--next', 'next', and 'main' for inconsistencies
+exports['Manifest buildPullRequests should report issue via PR comment if labeled as custom version but version not found in title 1'] = `
+
+## Invalid version number in PR title
+
+:rotating_light: This Pull Request has the \`autorelease: custom version\` label but the version number cannot be found in the title. Instead the generated version \`0.2.4\` will be used.
+
+If you want to use a custom version be sure to use the semver format.
+
+If you do not want to set a custom version and want  to get rid of this warning, remove the label \`autorelease: custom version\` from this Pull Request.
+
+`
+
+exports['Manifest buildPullRequests should use version from existing PR title if differs from release branch manifest 1'] = `
+
+## Release version edited manually
+
+The Pull Request version has been manually set to \`4.5.6-beta.1\` and will be used for the release.
+
+If you instead want to use the version number \`0.2.4\` generated from conventional commits, just remove the label \`autorelease: custom version\` from this Pull Request.
+
 `

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -497,7 +497,7 @@ const createReleasePullRequestCommand: yargs.CommandModule<
     }
 
     if (argv.dryRun) {
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests([], []);
       logger.debug(`Would open ${pullRequests.length} pull requests`);
       logger.debug('fork:', manifest.fork);
       logger.debug('changes branch:', manifest.changesBranch);
@@ -632,7 +632,7 @@ const createManifestPullRequestCommand: yargs.CommandModule<
     );
 
     if (argv.dryRun) {
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests([], []);
       logger.debug(`Would open ${pullRequests.length} pull requests`);
       logger.debug('fork:', manifest.fork);
       for (const pullRequest of pullRequests) {

--- a/src/factories/plugin-factory.ts
+++ b/src/factories/plugin-factory.ts
@@ -56,6 +56,7 @@ const pluginFactories: Record<string, PluginBuilder> = {
     new LinkedVersions(
       options.github,
       options.targetBranch,
+      options.manifestPath,
       options.repositoryConfig,
       (options.type as LinkedVersionPluginConfig).groupName,
       (options.type as LinkedVersionPluginConfig).components,
@@ -68,6 +69,7 @@ const pluginFactories: Record<string, PluginBuilder> = {
     new CargoWorkspace(
       options.github,
       options.targetBranch,
+      options.manifestPath,
       options.repositoryConfig,
       {
         ...options,
@@ -78,6 +80,7 @@ const pluginFactories: Record<string, PluginBuilder> = {
     new NodeWorkspace(
       options.github,
       options.targetBranch,
+      options.manifestPath,
       options.repositoryConfig,
       {
         ...options,
@@ -88,6 +91,7 @@ const pluginFactories: Record<string, PluginBuilder> = {
     new MavenWorkspace(
       options.github,
       options.targetBranch,
+      options.manifestPath,
       options.repositoryConfig,
       {
         ...options,
@@ -98,6 +102,7 @@ const pluginFactories: Record<string, PluginBuilder> = {
     new SentenceCase(
       options.github,
       options.targetBranch,
+      options.manifestPath,
       options.repositoryConfig,
       (options.type as SentenceCasePluginConfig).specialWords
     ),
@@ -105,6 +110,7 @@ const pluginFactories: Record<string, PluginBuilder> = {
     new GroupPriority(
       options.github,
       options.targetBranch,
+      options.manifestPath,
       options.repositoryConfig,
       (options.type as GroupPriorityPluginConfig).groups
     ),

--- a/src/github.ts
+++ b/src/github.ts
@@ -1495,6 +1495,7 @@ export class GitHub {
       release: Release,
       options: ReleaseOptions = {}
     ): Promise<GitHubRelease> => {
+      this.logger.debug({tag: release.tag});
       const resp = await this.octokit.repos.createRelease({
         name: release.name,
         owner: this.repository.owner,
@@ -1751,7 +1752,7 @@ export class GitHub {
     branchName: string,
     branchSha: string
   ): Promise<string> {
-    this.logger.debug(`Creating new branch: '${branchName}' at $'{branchSha}'`);
+    this.logger.debug(`Creating new branch: '${branchName}' at '${branchSha}'`);
     const {
       data: {
         object: {sha},

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -743,6 +743,8 @@ export class Manifest {
         openPullRequests.find(pr => pr.headBranchName === branchName) ||
         snoozedPullRequests.find(pr => pr.headBranchName === branchName);
 
+      this.logger.debug({existingPR});
+
       const releasePullRequest = await strategy.buildReleasePullRequest({
         commits: pathCommits,
         latestRelease,

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -784,10 +784,16 @@ export class Manifest {
     // pull requests
     if (!this.separatePullRequests) {
       this.plugins.push(
-        new Merge(this.github, this.targetBranch, this.repositoryConfig, {
-          pullRequestTitlePattern: this.groupPullRequestTitlePattern,
-          changesBranch: this.changesBranch,
-        })
+        new Merge(
+          this.github,
+          this.targetBranch,
+          this.manifestPath,
+          this.repositoryConfig,
+          {
+            pullRequestTitlePattern: this.groupPullRequestTitlePattern,
+            changesBranch: this.changesBranch,
+          }
+        )
       );
     }
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -264,6 +264,7 @@ export const DEFAULT_RELEASE_LABELS = ['autorelease: tagged'];
 export const DEFAULT_SNAPSHOT_LABELS = ['autorelease: snapshot'];
 export const SNOOZE_LABEL = 'autorelease: snooze';
 export const DEFAULT_PRERELEASE_LABELS = ['autorelease: pre-release'];
+export const DEFAULT_CUSTOM_VERSION_LABEL = 'autorelease: custom version';
 const DEFAULT_RELEASE_SEARCH_DEPTH = 400;
 const DEFAULT_COMMIT_SEARCH_DEPTH = 500;
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -34,16 +34,19 @@ export abstract class ManifestPlugin {
   readonly github: GitHub;
   readonly targetBranch: string;
   readonly changesBranch: string;
+  readonly manifestPath: string;
   readonly repositoryConfig: RepositoryConfig;
   protected logger: Logger;
   constructor(
     github: GitHub,
     targetBranch: string,
+    manifestPath: string,
     repositoryConfig: RepositoryConfig,
     options: ManifestPluginOptions
   ) {
     this.github = github;
     this.targetBranch = targetBranch;
+    this.manifestPath = manifestPath;
     this.repositoryConfig = repositoryConfig;
     this.changesBranch = options?.changesBranch || this.targetBranch;
     this.logger = options.logger || defaultLogger;

--- a/src/plugins/group-priority.ts
+++ b/src/plugins/group-priority.ts
@@ -35,11 +35,12 @@ export class GroupPriority extends ManifestPlugin {
   constructor(
     github: GitHub,
     targetBranch: string,
+    manifestPath: string,
     repositoryConfig: RepositoryConfig,
     groups: string[],
     options: ManifestPluginOptions = {}
   ) {
-    super(github, targetBranch, repositoryConfig, options);
+    super(github, targetBranch, manifestPath, repositoryConfig, options);
     this.groups = groups;
   }
 

--- a/src/plugins/maven-workspace.ts
+++ b/src/plugins/maven-workspace.ts
@@ -81,10 +81,11 @@ export class MavenWorkspace extends WorkspacePlugin<MavenArtifact> {
   constructor(
     github: GitHub,
     targetBranch: string,
+    manifestPath: string,
     repositoryConfig: RepositoryConfig,
     options: MavenWorkspacePluginOptions = {}
   ) {
-    super(github, targetBranch, repositoryConfig, options);
+    super(github, targetBranch, manifestPath, repositoryConfig, options);
     this.considerAllArtifacts = options.considerAllArtifacts ?? true;
   }
   private async fetchPom(path: string): Promise<MavenArtifact | undefined> {

--- a/src/plugins/merge.ts
+++ b/src/plugins/merge.ts
@@ -48,10 +48,11 @@ export class Merge extends ManifestPlugin {
   constructor(
     github: GitHub,
     targetBranch: string,
+    manifestPath: string,
     repositoryConfig: RepositoryConfig,
     options: MergeOptions = {}
   ) {
-    super(github, targetBranch, repositoryConfig, options);
+    super(github, targetBranch, manifestPath, repositoryConfig, options);
     this.pullRequestTitlePattern =
       options.pullRequestTitlePattern ?? MANIFEST_PULL_REQUEST_TITLE_PATTERN;
     this.pullRequestHeader = options.pullRequestHeader;

--- a/src/plugins/node-workspace.ts
+++ b/src/plugins/node-workspace.ts
@@ -68,10 +68,11 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
   constructor(
     github: GitHub,
     targetBranch: string,
+    manifestPath: string,
     repositoryConfig: RepositoryConfig,
     options: NodeWorkspaceOptions = {}
   ) {
-    super(github, targetBranch, repositoryConfig, options);
+    super(github, targetBranch, manifestPath, repositoryConfig, options);
     this.alwaysLinkLocal = options.alwaysLinkLocal === false ? false : true;
   }
   protected async buildAllPackages(

--- a/src/plugins/sentence-case.ts
+++ b/src/plugins/sentence-case.ts
@@ -29,11 +29,12 @@ export class SentenceCase extends ManifestPlugin {
   constructor(
     github: GitHub,
     targetBranch: string,
+    manifestPath: string,
     repositoryConfig: RepositoryConfig,
     specialWords?: Array<string>,
     options: ManifestPluginOptions = {}
   ) {
-    super(github, targetBranch, repositoryConfig, options);
+    super(github, targetBranch, manifestPath, repositoryConfig, options);
     this.specialWords = new Set(
       specialWords ? [...specialWords] : SPECIAL_WORDS
     );

--- a/src/plugins/workspace.ts
+++ b/src/plugins/workspace.ts
@@ -55,16 +55,15 @@ export interface AllPackages<T> {
  */
 export abstract class WorkspacePlugin<T> extends ManifestPlugin {
   private updateAllPackages: boolean;
-  private manifestPath: string;
   private merge: boolean;
   constructor(
     github: GitHub,
     targetBranch: string,
+    manifestPath: string,
     repositoryConfig: RepositoryConfig,
     options: WorkspacePluginOptions = {}
   ) {
-    super(github, targetBranch, repositoryConfig, options);
-    this.manifestPath = options.manifestPath ?? DEFAULT_RELEASE_PLEASE_MANIFEST;
+    super(github, targetBranch, manifestPath, repositoryConfig, options);
     this.updateAllPackages = options.updateAllPackages ?? false;
     this.merge = options.merge ?? true;
   }
@@ -170,6 +169,7 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
       const mergePlugin = new Merge(
         this.github,
         this.targetBranch,
+        this.manifestPath,
         this.repositoryConfig
       );
       newCandidates = await mergePlugin.run(newCandidates);

--- a/src/plugins/workspace.ts
+++ b/src/plugins/workspace.ts
@@ -16,7 +16,6 @@ import {ManifestPlugin, ManifestPluginOptions} from '../plugin';
 import {
   CandidateReleasePullRequest,
   RepositoryConfig,
-  DEFAULT_RELEASE_PLEASE_MANIFEST,
   ROOT_PROJECT_PATH,
 } from '../manifest';
 import {logger as defaultLogger, Logger} from '../util/logger';

--- a/src/release-pull-request.ts
+++ b/src/release-pull-request.ts
@@ -20,7 +20,7 @@ import {PullRequestTitle} from './util/pull-request-title';
 export interface ReleasePullRequest {
   readonly title: PullRequestTitle;
   readonly body: PullRequestBody;
-  readonly labels: string[];
+  labels: string[];
   readonly headRefName: string;
   readonly version?: Version;
   readonly draft: boolean;

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -22,6 +22,7 @@ import {
   MANIFEST_PULL_REQUEST_TITLE_PATTERN,
   ExtraFile,
   DEFAULT_CUSTOM_VERSION_LABEL,
+  DEFAULT_RELEASE_PLEASE_MANIFEST,
 } from '../manifest';
 import {DefaultVersioningStrategy} from '../versioning-strategies/default';
 import {DefaultChangelogNotes} from '../changelog-notes/default';
@@ -280,7 +281,7 @@ export abstract class BaseStrategy implements Strategy {
     draft?: boolean;
     labels?: string[];
     existingPullRequest?: PullRequest;
-    manifestPath: string;
+    manifestPath?: string;
   }): Promise<ReleasePullRequest | undefined> {
     const conventionalCommits = await this.postProcessCommits(commits);
     this.logger.info(`Considering: ${conventionalCommits.length} commits`);
@@ -330,7 +331,7 @@ export abstract class BaseStrategy implements Strategy {
       try {
         const manifest =
           (await this.github.getFileJson<Record<string, string>>(
-            manifestPath,
+            manifestPath || DEFAULT_RELEASE_PLEASE_MANIFEST,
             existingPullRequest.headBranchName
           )) || {};
         const componentVersion = manifest[component || '.'];

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -21,8 +21,6 @@ import {
   ROOT_PROJECT_PATH,
   MANIFEST_PULL_REQUEST_TITLE_PATTERN,
   ExtraFile,
-  Manifest,
-  ManifestConfig,
   DEFAULT_CUSTOM_VERSION_LABEL,
 } from '../manifest';
 import {DefaultVersioningStrategy} from '../versioning-strategies/default';
@@ -280,7 +278,7 @@ export abstract class BaseStrategy implements Strategy {
     commits: ConventionalCommit[];
     latestRelease?: Release;
     draft?: boolean;
-    labels: string[];
+    labels?: string[];
     existingPullRequest?: PullRequest;
     manifestPath: string;
   }): Promise<ReleasePullRequest | undefined> {
@@ -362,7 +360,7 @@ If you instead want to use the version number \`${newVersion}\` generated from c
       } catch (err: unknown) {
         if (err instanceof FileNotFoundError) {
           this.logger.error(
-            `Manifest file was expected to exist on PR branch but was not found. Check for PR title edits aborted.`,
+            'Manifest file was expected to exist on PR branch but was not found. Check for PR title edits aborted.',
             err
           );
         } else {

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -331,7 +331,7 @@ export abstract class BaseStrategy implements Strategy {
       );
 
       if (!existingPRTitleVersion && hasCustomVersionLabel) {
-        // report error
+        // report problem to end user
         this.github.commentOnIssue(
           `
 ## Invalid version number in PR title
@@ -345,7 +345,17 @@ If you do not want to set a custom version and want  to get rid of this warning,
           existingPullRequest.number
         );
       } else if (!existingPRTitleVersion) {
-        // do nothing
+        // warn end user
+        this.github.commentOnIssue(
+          `
+## Invalid version number in PR title
+
+:warning: No version number can be found in the title. Did you want to set a custom version for this release?
+
+To set a custom version be sure to use the semver format, e.g \`1.2.3\`.
+`,
+          existingPullRequest.number
+        );
       } else if (
         existingPullRequest.labels.find(
           label => label === DEFAULT_CUSTOM_VERSION_LABEL

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -338,7 +338,7 @@ export abstract class BaseStrategy implements Strategy {
 
 :rotating_light: This Pull Request has the \`${DEFAULT_CUSTOM_VERSION_LABEL}\` label but the version number cannot be found in the title. Instead the generated version \`${newVersion}\` will be used.
 
-If you want to use a custom version be sure to use the semver format.
+If you want to set a custom version be sure to use the [semantic versioning format](https://devhints.io/semver).
 
 If you do not want to set a custom version and want  to get rid of this warning, remove the label \`${DEFAULT_CUSTOM_VERSION_LABEL}\` from this Pull Request.
 `,

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -338,7 +338,7 @@ export abstract class BaseStrategy implements Strategy {
 
 :rotating_light: This Pull Request has the \`${DEFAULT_CUSTOM_VERSION_LABEL}\` label but the version number cannot be found in the title. Instead the generated version \`${newVersion}\` will be used.
 
-If you want to set a custom version be sure to use the [semantic versioning format](https://devhints.io/semver).
+If you want to set a custom version be sure to use the [semantic versioning format](https://devhints.io/semver), e.g \`1.2.3\`.
 
 If you do not want to set a custom version and want  to get rid of this warning, remove the label \`${DEFAULT_CUSTOM_VERSION_LABEL}\` from this Pull Request.
 `,
@@ -350,9 +350,9 @@ If you do not want to set a custom version and want  to get rid of this warning,
           `
 ## Invalid version number in PR title
 
-:warning: No version number can be found in the title. Did you want to set a custom version for this release?
+:warning: No version number can be found in the title, the generated version \`${newVersion}\` will be used. Did you want to change the version for this release?
 
-To set a custom version be sure to use the semver format, e.g \`1.2.3\`.
+To set a custom version be sure to use the [semantic versioning format](https://devhints.io/semver), e.g \`1.2.3\`.
 `,
           existingPullRequest.number
         );

--- a/src/strategies/java.ts
+++ b/src/strategies/java.ts
@@ -76,7 +76,6 @@ export class Java extends BaseStrategy {
 
   async buildReleasePullRequest({
     commits,
-    existingPullRequest,
     labels = [],
     latestRelease,
     draft,
@@ -87,7 +86,7 @@ export class Java extends BaseStrategy {
     draft?: boolean;
     labels?: string[];
     existingPullRequest?: PullRequest;
-    manifestPath: string;
+    manifestPath?: string;
   }): Promise<ReleasePullRequest | undefined> {
     if (await this.needsSnapshot(commits, latestRelease)) {
       this.logger.info('Repository needs a snapshot bump.');

--- a/src/strategies/node.ts
+++ b/src/strategies/node.ts
@@ -103,6 +103,11 @@ export class Node extends BaseStrategy {
 
   protected async getPkgJsonContents(): Promise<GitHubFileContents> {
     if (!this.pkgJsonContents) {
+      const errMissingFile = new MissingRequiredFileError(
+        this.addPath('package.json'),
+        'node',
+        `${this.repository.owner}/${this.repository.repo}#${this.changesBranch}`
+      );
       try {
         this.pkgJsonContents = await this.github.getFileContentsOnBranch(
           this.addPath('package.json'),
@@ -110,13 +115,12 @@ export class Node extends BaseStrategy {
         );
       } catch (e) {
         if (e instanceof FileNotFoundError) {
-          throw new MissingRequiredFileError(
-            this.addPath('package.json'),
-            'node',
-            `${this.repository.owner}/${this.repository.repo}`
-          );
+          throw errMissingFile;
         }
         throw e;
+      }
+      if (!this.pkgJsonContents) {
+        throw errMissingFile;
       }
     }
     return this.pkgJsonContents;

--- a/src/strategies/php-yoshi.ts
+++ b/src/strategies/php-yoshi.ts
@@ -18,7 +18,7 @@ import {Changelog} from '../updaters/changelog';
 import {RootComposerUpdatePackages} from '../updaters/php/root-composer-update-packages';
 import {PHPClientVersion} from '../updaters/php/php-client-version';
 import {VersionsMap, Version} from '../version';
-import {Commit, parseConventionalCommits} from '../commit';
+import {Commit, ConventionalCommit, parseConventionalCommits} from '../commit';
 import {CommitSplit} from '../util/commit-split';
 import {DefaultUpdater} from '../updaters/default';
 import {Release} from '../release';
@@ -29,6 +29,7 @@ import {BranchName} from '../util/branch-name';
 import {PullRequestBody} from '../util/pull-request-body';
 import {GitHubFileContents} from '@google-automations/git-file-utils';
 import {FileNotFoundError} from '../errors';
+import {PullRequest} from '../pull-request';
 
 const CHANGELOG_SECTIONS = [
   {type: 'feat', section: 'Features'},
@@ -64,12 +65,21 @@ export class PHPYoshi extends BaseStrategy {
       changelogSections: CHANGELOG_SECTIONS,
     });
   }
-  async buildReleasePullRequest(
-    commits: Commit[],
-    latestRelease?: Release,
-    draft?: boolean,
-    labels: string[] = []
-  ): Promise<ReleasePullRequest | undefined> {
+  async buildReleasePullRequest({
+    commits,
+    existingPullRequest,
+    labels = [],
+    latestRelease,
+    draft,
+    manifestPath,
+  }: {
+    commits: ConventionalCommit[];
+    latestRelease?: Release;
+    draft?: boolean;
+    labels?: string[];
+    existingPullRequest?: PullRequest;
+    manifestPath: string;
+  }): Promise<ReleasePullRequest | undefined> {
     const conventionalCommits = await this.postProcessCommits(
       parseConventionalCommits(commits, this.logger)
     );

--- a/src/strategies/php-yoshi.ts
+++ b/src/strategies/php-yoshi.ts
@@ -18,7 +18,7 @@ import {Changelog} from '../updaters/changelog';
 import {RootComposerUpdatePackages} from '../updaters/php/root-composer-update-packages';
 import {PHPClientVersion} from '../updaters/php/php-client-version';
 import {VersionsMap, Version} from '../version';
-import {Commit, ConventionalCommit, parseConventionalCommits} from '../commit';
+import {Commit, parseConventionalCommits} from '../commit';
 import {CommitSplit} from '../util/commit-split';
 import {DefaultUpdater} from '../updaters/default';
 import {Release} from '../release';

--- a/src/strategies/php-yoshi.ts
+++ b/src/strategies/php-yoshi.ts
@@ -67,18 +67,16 @@ export class PHPYoshi extends BaseStrategy {
   }
   async buildReleasePullRequest({
     commits,
-    existingPullRequest,
     labels = [],
     latestRelease,
     draft,
-    manifestPath,
   }: {
-    commits: ConventionalCommit[];
+    commits: Commit[];
     latestRelease?: Release;
     draft?: boolean;
     labels?: string[];
     existingPullRequest?: PullRequest;
-    manifestPath: string;
+    manifestPath?: string;
   }): Promise<ReleasePullRequest | undefined> {
     const conventionalCommits = await this.postProcessCommits(
       parseConventionalCommits(commits, this.logger)

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -45,13 +45,14 @@ export interface Strategy {
    * @returns {ReleasePullRequest | undefined} The release pull request to open for this path/component. Returns
    * undefined if we should not open a pull request.
    */
-  buildReleasePullRequest(
-    commits: Commit[],
-    latestRelease?: Release,
-    draft?: boolean,
-    labels?: string[],
-    existingPullRequest?: PullRequest
-  ): Promise<ReleasePullRequest | undefined>;
+  buildReleasePullRequest(opts: {
+    commits: Commit[];
+    latestRelease?: Release;
+    draft?: boolean;
+    labels?: string[];
+    existingPullRequest?: PullRequest;
+    manifestPath: string;
+  }): Promise<ReleasePullRequest | undefined>;
 
   /**
    * Given a merged pull request, build the candidate release.

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -51,7 +51,7 @@ export interface Strategy {
     draft?: boolean;
     labels?: string[];
     existingPullRequest?: PullRequest;
-    manifestPath: string;
+    manifestPath?: string;
   }): Promise<ReleasePullRequest | undefined>;
 
   /**

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -19,6 +19,7 @@ import {Commit} from './commit';
 import {VersioningStrategy} from './versioning-strategy';
 import {ChangelogNotes} from './changelog-notes';
 import {Version} from './version';
+import {BranchName} from './util/branch-name';
 
 export interface BuildReleaseOptions {
   groupPullRequestTitlePattern?: string;
@@ -39,15 +40,17 @@ export interface Strategy {
    *   component if available.
    * @param {boolean} draft Optional. Whether or not to create the pull
    *   request as a draft. Defaults to `false`.
-   * @returns {ReleasePullRequest | undefined} The release pull request to
-   *   open for this path/component. Returns undefined if we should not
-   *   open a pull request.
+   * @param {string[]} labels Optional.
+   * @param {PullRequest} existingPullRequest Optional. A pull request already existing for this branch.
+   * @returns {ReleasePullRequest | undefined} The release pull request to open for this path/component. Returns
+   * undefined if we should not open a pull request.
    */
   buildReleasePullRequest(
     commits: Commit[],
     latestRelease?: Release,
     draft?: boolean,
-    labels?: string[]
+    labels?: string[],
+    existingPullRequest?: PullRequest
   ): Promise<ReleasePullRequest | undefined>;
 
   /**
@@ -83,6 +86,8 @@ export interface Strategy {
    * @returns {string}
    */
   getBranchComponent(): Promise<string | undefined>;
+
+  getBranchName(): Promise<BranchName>;
 
   /**
    * Validate whether version is a valid release.

--- a/test/factories/plugin-factory.ts
+++ b/test/factories/plugin-factory.ts
@@ -126,6 +126,7 @@ describe('PluginFactory', () => {
           new CustomTest(
             options.github,
             options.targetBranch,
+            options.manifestPath,
             options.repositoryConfig,
             {}
           )
@@ -148,6 +149,7 @@ describe('PluginFactory', () => {
           new CustomTest(
             options.github,
             options.targetBranch,
+            options.manifestPath,
             options.repositoryConfig,
             {}
           )

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -1517,7 +1517,7 @@ describe('Manifest', () => {
             '.': Version.parse('1.0.0'),
           }
         );
-        const pullRequests = await manifest.buildPullRequests();
+        const pullRequests = await manifest.buildPullRequests([], []);
         expect(pullRequests).lengthOf(1);
         const pullRequest = pullRequests[0];
         expect(pullRequest.version?.toString()).to.eql('1.0.1');
@@ -1554,7 +1554,7 @@ describe('Manifest', () => {
           undefined,
           'non/default/path/manifest.json'
         );
-        const pullRequests = await manifest.buildPullRequests();
+        const pullRequests = await manifest.buildPullRequests([], []);
         expect(pullRequests).lengthOf(1);
         const pullRequest = pullRequests[0];
         assertHasUpdate(pullRequest.updates, 'non/default/path/manifest.json');
@@ -1574,7 +1574,7 @@ describe('Manifest', () => {
             '.': Version.parse('1.0.0'),
           }
         );
-        const pullRequests = await manifest.buildPullRequests();
+        const pullRequests = await manifest.buildPullRequests([], []);
         expect(pullRequests).lengthOf(1);
         const pullRequest = pullRequests[0];
         expect(pullRequest.draft).to.be.true;
@@ -1596,7 +1596,7 @@ describe('Manifest', () => {
             draftPullRequest: true,
           }
         );
-        const pullRequests = await manifest.buildPullRequests();
+        const pullRequests = await manifest.buildPullRequests([], []);
         expect(pullRequests).lengthOf(1);
         const pullRequest = pullRequests[0];
         expect(pullRequest.draft).to.be.true;
@@ -1618,7 +1618,7 @@ describe('Manifest', () => {
             labels: ['some-special-label'],
           }
         );
-        const pullRequests = await manifest.buildPullRequests();
+        const pullRequests = await manifest.buildPullRequests([], []);
         expect(pullRequests).lengthOf(1);
         const pullRequest = pullRequests[0];
         expect(pullRequest.labels).to.eql(['some-special-label']);
@@ -1638,7 +1638,7 @@ describe('Manifest', () => {
             '.': Version.parse('1.0.0'),
           }
         );
-        const pullRequests = await manifest.buildPullRequests();
+        const pullRequests = await manifest.buildPullRequests([], []);
         expect(pullRequests).lengthOf(1);
         const pullRequest = pullRequests[0];
         expect(pullRequest.title.toString()).to.eql('release: 1.0.1');
@@ -1658,7 +1658,7 @@ describe('Manifest', () => {
             '.': Version.parse('1.0.0'),
           }
         );
-        const pullRequests = await manifest.buildPullRequests();
+        const pullRequests = await manifest.buildPullRequests([], []);
         expect(pullRequests).lengthOf(1);
         const pullRequest = pullRequests[0];
         expect(pullRequest.body.header.toString()).to.eql(
@@ -1722,7 +1722,7 @@ describe('Manifest', () => {
           '.': Version.parse('1.0.0'),
         }
       );
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(1);
       const pullRequest = pullRequests[0];
       expect(pullRequest.version?.toString()).to.eql('1.0.1');
@@ -1811,7 +1811,7 @@ describe('Manifest', () => {
           'path/b': Version.parse('0.2.3'),
         }
       );
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(1);
       expect(pullRequests[0].labels).to.eql(['autorelease: pending']);
       snapshot(dateSafe(pullRequests[0].body.toString()));
@@ -1900,7 +1900,7 @@ describe('Manifest', () => {
           separatePullRequests: true,
         }
       );
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(2);
       snapshot(dateSafe(pullRequests[0].body.toString()));
       snapshot(dateSafe(pullRequests[1].body.toString()));
@@ -1993,7 +1993,7 @@ describe('Manifest', () => {
         .withArgs('.release-please-manifest.json', 'main')
         .resolves(buildGitHubFileRaw(JSON.stringify(versions)));
       const manifest = await Manifest.fromManifest(github, 'main');
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(2);
       expect(pullRequests[0].version?.toString()).to.eql('1.0.1');
       expect(pullRequests[1].version?.toString()).to.eql('3.3.3');
@@ -2086,7 +2086,7 @@ describe('Manifest', () => {
         .withArgs('.release-please-manifest.json', 'main')
         .resolves(buildGitHubFileRaw(JSON.stringify(versions)));
       const manifest = await Manifest.fromManifest(github, 'main');
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(2);
       expect(pullRequests[0].version?.toString()).to.eql('3.3.3');
       expect(pullRequests[1].version?.toString()).to.eql('3.3.3');
@@ -2142,7 +2142,7 @@ describe('Manifest', () => {
         .withArgs('.release-please-manifest.json', 'main')
         .resolves(buildGitHubFileRaw(JSON.stringify(versions)));
       const manifest = await Manifest.fromManifest(github, 'main');
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(1);
       expect(pullRequests[0].version?.toString()).to.eql('1.0.0');
     });
@@ -2235,7 +2235,7 @@ describe('Manifest', () => {
         .withArgs('.release-please-manifest.json', 'main')
         .resolves(buildGitHubFileRaw(JSON.stringify(versions)));
       const manifest = await Manifest.fromManifest(github, 'main');
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(1);
       expect(pullRequests[0].version?.toString()).to.eql('1.0.0');
     });
@@ -2347,7 +2347,7 @@ describe('Manifest', () => {
             'chore${scope}: release${component} v${version}',
         }
       );
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(1);
       const pullRequest = pullRequests[0];
       expect(pullRequest.title.toString()).to.eql(
@@ -2446,7 +2446,7 @@ describe('Manifest', () => {
             'chore${scope}: release${component} v${version}',
         }
       );
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(1);
       expect(pullRequests[0].title.toString()).to.eql('chore(main): release v');
     });
@@ -2489,7 +2489,7 @@ describe('Manifest', () => {
         .withArgs('.release-please-manifest.json', 'main')
         .resolves(buildGitHubFileRaw(JSON.stringify(versions)));
       const manifest = await Manifest.fromManifest(github, 'main');
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(1);
       expect(pullRequests[0].body.releaseData).lengthOf(1);
       expect(pullRequests[0].body.releaseData[0].component).to.eql('pkg1');
@@ -2536,7 +2536,7 @@ describe('Manifest', () => {
           '.': Version.parse('1.2.3'),
         }
       );
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(1);
       const pullRequest = pullRequests[0];
       expect(pullRequest.version?.toString()).to.eql('1.2.4-SNAPSHOT');
@@ -2571,7 +2571,7 @@ describe('Manifest', () => {
             '.': Version.parse('1.0.0'),
           }
         );
-        const pullRequests = await manifest.buildPullRequests();
+        const pullRequests = await manifest.buildPullRequests([], []);
         expect(pullRequests).lengthOf(0);
       });
 
@@ -2601,7 +2601,7 @@ describe('Manifest', () => {
             '.': Version.parse('1.0.0'),
           }
         );
-        const pullRequests = await manifest.buildPullRequests();
+        const pullRequests = await manifest.buildPullRequests([], []);
         expect(pullRequests).lengthOf(1);
         const pullRequest = pullRequests[0];
         expect(pullRequest.version?.toString()).to.eql('1.0.1-SNAPSHOT');
@@ -2659,7 +2659,7 @@ describe('Manifest', () => {
           'pkg/c': Version.parse('1.0.1'),
         }
       );
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(1);
       expect(pullRequests[0].updates).to.be.an('array');
       expect(pullRequests[0].updates.map(update => update.path))
@@ -2733,7 +2733,7 @@ describe('Manifest', () => {
           draftPullRequest: true,
         }
       );
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(1);
       const pullRequest = pullRequests[0];
       safeSnapshot(pullRequest.body.toString());
@@ -2837,7 +2837,7 @@ describe('Manifest', () => {
             plugins: ['node-workspace'],
           }
         );
-        const pullRequests = await manifest.buildPullRequests();
+        const pullRequests = await manifest.buildPullRequests([], []);
         expect(pullRequests).not.empty;
         sinon.assert.calledOnce(mockPlugin.run);
       });
@@ -2881,7 +2881,7 @@ describe('Manifest', () => {
             plugins: ['node-workspace', 'cargo-workspace'],
           }
         );
-        const pullRequests = await manifest.buildPullRequests();
+        const pullRequests = await manifest.buildPullRequests([], []);
         expect(pullRequests).not.empty;
         sinon.assert.calledOnce(mockPlugin.run);
         sinon.assert.calledOnce(mockPlugin2.run);
@@ -2912,7 +2912,7 @@ describe('Manifest', () => {
             plugins: ['sentence-case'],
           }
         );
-        const pullRequests = await manifest.buildPullRequests();
+        const pullRequests = await manifest.buildPullRequests([], []);
         expect(pullRequests).not.empty;
         // This assertion verifies that conventional commit parsing
         // was applied before calling the processCommits plugin hook:
@@ -2999,7 +2999,7 @@ describe('Manifest', () => {
           '.': Version.parse('1.0.0'),
         }
       );
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(1);
       const pullRequest = pullRequests[0];
       expect(pullRequest.version?.toString()).to.eql('1.0.1');
@@ -3089,7 +3089,7 @@ describe('Manifest', () => {
           'path/b': Version.parse('0.2.3'),
         }
       );
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(1);
       expect(pullRequests[0].labels).to.eql(['autorelease: pending']);
       snapshot(dateSafe(pullRequests[0].body.toString()));
@@ -3153,7 +3153,7 @@ describe('Manifest', () => {
         }
       );
       expect(manifest.releaseSearchDepth).to.eql(1);
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(1);
       const pullRequest = pullRequests[0];
       expect(pullRequest.version?.toString()).to.eql('1.0.1');
@@ -3224,7 +3224,7 @@ describe('Manifest', () => {
         }
       );
       expect(manifest.commitSearchDepth).to.eql(1);
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(1);
       const pullRequest = pullRequests[0];
       expect(pullRequest.version?.toString()).to.eql('1.0.1');
@@ -3318,7 +3318,7 @@ describe('Manifest', () => {
             separatePullRequests: true,
           }
         );
-        const pullRequests = await manifest.buildPullRequests();
+        const pullRequests = await manifest.buildPullRequests([], []);
         expect(pullRequests).lengthOf(3);
         const pullRequestB = pullRequests[0];
         expect(pullRequestB.headRefName).to.eql(
@@ -3359,7 +3359,7 @@ describe('Manifest', () => {
             'pkg/d': Version.parse('3.0.0'),
           }
         );
-        const pullRequests = await manifest.buildPullRequests();
+        const pullRequests = await manifest.buildPullRequests([], []);
         expect(pullRequests).lengthOf(2);
         const pullRequest = pullRequests[0];
         expect(pullRequest.headRefName).to.eql(
@@ -3397,7 +3397,7 @@ describe('Manifest', () => {
             'pkg/d': Version.parse('3.0.0'),
           }
         );
-        const pullRequests = await manifest.buildPullRequests();
+        const pullRequests = await manifest.buildPullRequests([], []);
         expect(pullRequests).lengthOf(2);
         const pullRequest = pullRequests[0];
         expect(pullRequest.headRefName).to.eql(

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {describe, it, beforeEach, afterEach} from 'mocha';
-import {Manifest} from '../src/manifest';
+import {DEFAULT_RELEASE_PLEASE_MANIFEST, Manifest} from '../src/manifest';
 import {GitHub, ReleaseOptions} from '../src/github';
 import * as githubModule from '../src/github';
 import * as sinon from 'sinon';
@@ -2888,7 +2888,9 @@ describe('Manifest', () => {
       });
 
       it('should apply plugin hook "processCommits"', async () => {
-        const spyPlugin = sinon.spy(new SentenceCase(github, 'main', {}));
+        const spyPlugin = sinon.spy(
+          new SentenceCase(github, 'main', DEFAULT_RELEASE_PLEASE_MANIFEST, {})
+        );
         sandbox
           .stub(pluginFactory, 'buildPlugin')
           .withArgs(sinon.match.has('type', 'sentence-case'))

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -2497,6 +2497,137 @@ describe('Manifest', () => {
       sinon.assert.called(getFileContentsOnBranchStub);
     });
 
+    it('should warn end user via PR comment if version not found in title and not labeled as custom version', async () => {
+      mockReleases(sandbox, github, [
+        {
+          id: 123456,
+          sha: 'abc123',
+          tagName: 'pkg1-v1.0.0',
+          url: 'https://github.com/fake-owner/fake-repo/releases/tag/pkg1-v1.0.0',
+        },
+        {
+          id: 654321,
+          sha: 'def234',
+          tagName: 'pkg2-v0.2.3',
+          url: 'https://github.com/fake-owner/fake-repo/releases/tag/pkg2-v1.0.0',
+        },
+      ]);
+      mockCommits(sandbox, github, [
+        {
+          sha: 'aaaaaa',
+          message: 'fix: some bugfix',
+          files: ['path/a/foo'],
+        },
+        {
+          sha: 'abc123',
+          message: 'chore: release 1.0.0',
+          files: [],
+          pullRequest: {
+            headBranchName:
+              'release-please--branches--main--changes--next--components--pkg1',
+            baseBranchName: 'main',
+            number: 123,
+            title: 'chore: release 1.0.0',
+            body: '',
+            labels: [],
+            files: [],
+            sha: 'abc123',
+          },
+        },
+        {
+          sha: 'bbbbbb',
+          message: 'fix: some bugfix',
+          files: ['path/b/foo'],
+        },
+        {
+          sha: 'cccccc',
+          message: 'fix: some bugfix',
+          files: ['path/a/foo'],
+        },
+        {
+          sha: 'def234',
+          message: 'chore: release 0.2.3',
+          files: [],
+          pullRequest: {
+            headBranchName:
+              'release-please--branches--main--changes--next--components--pkg2',
+            baseBranchName: 'main',
+            number: 123,
+            title: 'chore: release 0.2.3',
+            body: '',
+            labels: [],
+            files: [],
+            sha: 'def234',
+          },
+        },
+      ]);
+      const config = {
+        'separate-pull-requests': true,
+        packages: {
+          'path/a': {
+            'release-type': 'simple',
+            component: 'pkg1',
+          },
+          'path/b': {
+            'release-type': 'simple',
+            component: 'pkg2',
+          },
+        },
+      };
+
+      const getFileContentsOnBranchStub = sandbox
+        .stub(github, 'getFileContentsOnBranch')
+        .withArgs('release-please-config.json', 'main')
+        .resolves(buildGitHubFileRaw(JSON.stringify(config)))
+        .withArgs('.release-please-manifest.json', 'main')
+        .resolves(
+          buildGitHubFileRaw(
+            JSON.stringify({
+              'path/a': '1.0.0',
+              'path/b': '0.2.3',
+            })
+          )
+        );
+
+      let commented = false;
+      sandbox.replace(github, 'commentOnIssue', (comment, number) => {
+        snapshot(comment);
+        expect(number).to.eql(123);
+        commented = true;
+        return Promise.resolve('https://foo/bar');
+      });
+
+      const manifest = await Manifest.fromManifest(
+        github,
+        'main',
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
+      );
+
+      const pullRequests = await manifest.buildPullRequests(
+        [
+          {
+            // title edited by end user, version not valid anymore
+            title: 'chore(main): release vCHANGED_TO_SOMETHING_WITHOUT_VERSION',
+            body: 'some content',
+            headBranchName:
+              'release-please--branches--main--changes--next--components--pkg2',
+            baseBranchName: 'main',
+            number: 123,
+            labels: [], // no custom version label
+            files: [],
+          },
+        ],
+        []
+      );
+      expect(pullRequests).lengthOf(2);
+      expect(pullRequests[0].version?.toString()).to.eql('1.0.1');
+      expect(pullRequests[1].version?.toString()).to.eql('0.2.4'); // should not use version from title
+      expect(commented).to.be.true;
+      sinon.assert.called(getFileContentsOnBranchStub);
+    });
+
     it('should allow specifying a bootstrap sha', async () => {
       mockReleases(sandbox, github, []);
       mockCommits(sandbox, github, [

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_CUSTOM_VERSION_LABEL,
   DEFAULT_RELEASE_PLEASE_MANIFEST,
   Manifest,
+  ManifestConfig,
 } from '../src/manifest';
 import {GitHub, ReleaseOptions} from '../src/github';
 import * as githubModule from '../src/github';
@@ -1972,7 +1973,7 @@ describe('Manifest', () => {
           },
         },
       ]);
-      const config = {
+      const config: ManifestConfig = {
         'separate-pull-requests': true,
         packages: {
           'path/a': {
@@ -2065,7 +2066,7 @@ describe('Manifest', () => {
           },
         },
       ]);
-      const config = {
+      const config: ManifestConfig = {
         'release-as': '3.3.3',
         'separate-pull-requests': true,
         packages: {
@@ -2099,77 +2100,135 @@ describe('Manifest', () => {
     it('should use version from existing PR title if differs from release branch manifest', async () => {
       mockReleases(sandbox, github, [
         {
-          id: 123456,
-          sha: 'abc123',
+          id: 11111,
+          sha: 'commit1',
           tagName: 'pkg1-v1.0.0',
           url: 'https://github.com/fake-owner/fake-repo/releases/tag/pkg1-v1.0.0',
         },
         {
-          id: 654321,
-          sha: 'def234',
-          tagName: 'pkg2-v0.2.3',
-          url: 'https://github.com/fake-owner/fake-repo/releases/tag/pkg2-v1.0.0',
+          id: 22222,
+          sha: 'commit2',
+          tagName: 'pkg2-v2.0.0',
+          url: 'https://github.com/fake-owner/fake-repo/releases/tag/pkg2-v2.0.0',
+        },
+        {
+          id: 33333,
+          sha: 'commit3',
+          tagName: 'pkg3-v3.0.0',
+          url: 'https://github.com/fake-owner/fake-repo/releases/tag/pkg3-v3.0.0',
+        },
+        {
+          id: 44444,
+          sha: 'commit4',
+          tagName: 'pkg4-v4.0.0',
+          url: 'https://github.com/fake-owner/fake-repo/releases/tag/pkg4-v4.0.0',
         },
       ]);
       mockCommits(sandbox, github, [
         {
-          sha: 'aaaaaa',
+          sha: 'commit11',
           message: 'fix: some bugfix',
           files: ['path/a/foo'],
         },
         {
-          sha: 'abc123',
+          sha: 'commit22',
+          message: 'fix: some bugfix',
+          files: ['path/b/foo'],
+        },
+        {
+          sha: 'commit33',
+          message: 'fix: some bugfix',
+          files: ['path/c/foo'],
+        },
+        {
+          sha: 'commit44',
+          message: 'fix: some bugfix',
+          files: ['path/d/foo'],
+        },
+        {
+          sha: 'commit1',
           message: 'chore: release 1.0.0',
           files: [],
           pullRequest: {
             headBranchName:
               'release-please--branches--main--changes--next--components--pkg1',
             baseBranchName: 'main',
-            number: 123,
+            number: 111,
             title: 'chore: release 1.0.0',
             body: '',
             labels: [],
             files: [],
-            sha: 'abc123',
+            sha: 'commit1',
           },
         },
         {
-          sha: 'bbbbbb',
-          message: 'fix: some bugfix',
-          files: ['path/b/foo'],
-        },
-        {
-          sha: 'cccccc',
-          message: 'fix: some bugfix',
-          files: ['path/a/foo'],
-        },
-        {
-          sha: 'def234',
-          message: 'chore: release 0.2.3',
+          sha: 'commit2',
+          message: 'chore: release 2.0.0',
           files: [],
           pullRequest: {
             headBranchName:
               'release-please--branches--main--changes--next--components--pkg2',
             baseBranchName: 'main',
-            number: 123,
-            title: 'chore: release 0.2.3',
+            number: 222,
+            title: 'chore: release 2.0.0',
             body: '',
             labels: [],
             files: [],
-            sha: 'def234',
+            sha: 'commit2',
+          },
+        },
+        {
+          sha: 'commit3',
+          message: 'chore: release 3.0.0',
+          files: [],
+          pullRequest: {
+            headBranchName:
+              'release-please--branches--main--changes--next--components--pkg3',
+            baseBranchName: 'main',
+            number: 333,
+            title: 'chore: release 3.0.0',
+            body: '',
+            labels: [],
+            files: [],
+            sha: 'commit3',
+          },
+        },
+        {
+          sha: 'commit4',
+          message: 'chore: release 4.0.0',
+          files: [],
+          pullRequest: {
+            headBranchName:
+              'release-please--branches--main--changes--next--components--pkg4',
+            baseBranchName: 'main',
+            number: 444,
+            title: 'chore: release 4.0.0',
+            body: '',
+            labels: [],
+            files: [],
+            sha: 'commit4',
           },
         },
       ]);
-      const config = {
+      const config: ManifestConfig = {
         'separate-pull-requests': true,
+        'release-type': 'simple',
         packages: {
           'path/a': {
             'release-type': 'simple',
             component: 'pkg1',
           },
           'path/b': {
-            'release-type': 'simple',
+            'release-type': 'node',
             component: 'pkg2',
+          },
+          'path/c': {
+            'release-type': 'python',
+            component: 'pkg3',
+          },
+          'path/d': {
+            'release-type': 'go',
+            component: 'pkg4',
           },
         },
       };
@@ -2183,7 +2242,20 @@ describe('Manifest', () => {
           buildGitHubFileRaw(
             JSON.stringify({
               'path/a': '1.0.0',
-              'path/b': '0.2.3',
+              'path/b': '2.0.0',
+              'path/c': '3.0.0',
+              'path/d': '4.0.0',
+            })
+          )
+        )
+        .withArgs(
+          '.release-please-manifest.json',
+          'release-please--branches--main--changes--next--components--pkg1'
+        )
+        .resolves(
+          buildGitHubFileRaw(
+            JSON.stringify({
+              'path/a': '1.0.1',
             })
           )
         )
@@ -2194,22 +2266,66 @@ describe('Manifest', () => {
         .resolves(
           buildGitHubFileRaw(
             JSON.stringify({
-              'path/a': '1.0.1',
-              'path/b': '0.2.4',
+              'path/b': '2.0.1',
+            })
+          )
+        )
+        .withArgs('path/b/package.json', 'next')
+        .resolves(
+          buildGitHubFileRaw(
+            JSON.stringify({
+              name: 'pkg2',
+            })
+          )
+        )
+        .withArgs(
+          '.release-please-manifest.json',
+          'release-please--branches--main--changes--next--components--pkg3'
+        )
+        .resolves(
+          buildGitHubFileRaw(
+            JSON.stringify({
+              'path/c': '3.0.1',
+            })
+          )
+        )
+        .withArgs('path/c/setup.py', 'next')
+        .resolves(
+          buildGitHubFileRaw(
+            `
+name = "pkg3"
+description = "Something"
+version = "3.0.0"
+`
+          )
+        )
+        .withArgs(
+          '.release-please-manifest.json',
+          'release-please--branches--main--changes--next--components--pkg4'
+        )
+        .resolves(
+          buildGitHubFileRaw(
+            JSON.stringify({
+              'path/d': '4.0.1',
             })
           )
         );
 
+      const findFilesByFilenameAndRefStub = sandbox
+        .stub(github, 'findFilesByFilenameAndRef')
+        .withArgs('version.py', 'next', 'path/c')
+        .resolves([]);
+
       const addIssueLabelsStub = sandbox
         .stub(github, 'addIssueLabels')
-        .withArgs([DEFAULT_CUSTOM_VERSION_LABEL], 123)
+        .withArgs([DEFAULT_CUSTOM_VERSION_LABEL], 111)
         .resolves();
 
-      let commented = false;
+      let commentCount = 0;
       sandbox.replace(github, 'commentOnIssue', (comment, number) => {
         snapshot(comment);
-        expect(number).to.eql(123);
-        commented = true;
+        expect(number).to.be.oneOf([111, 222, 333, 444]);
+        commentCount += 1;
         return Promise.resolve('https://foo/bar');
       });
 
@@ -2224,25 +2340,57 @@ describe('Manifest', () => {
       const pullRequests = await manifest.buildPullRequests(
         [
           {
-            title: 'chore(main): release v4.5.6-beta.1', // version from title differs from PR manifest
+            title: 'chore(main): release v6.7.9-alpha.1', // version from title differs from PR manifest
+            body: 'some content',
+            headBranchName:
+              'release-please--branches--main--changes--next--components--pkg1',
+            baseBranchName: 'main',
+            number: 111,
+            labels: [],
+            files: [],
+          },
+          {
+            title: 'chore(main): release v7.8.9', // version from title differs from PR manifest
             body: 'some content',
             headBranchName:
               'release-please--branches--main--changes--next--components--pkg2',
             baseBranchName: 'main',
-            number: 123,
+            number: 222,
+            labels: [],
+            files: [],
+          },
+          {
+            title: 'chore(main): release 8.9.0', // version from title differs from PR manifest
+            body: 'some content',
+            headBranchName:
+              'release-please--branches--main--changes--next--components--pkg3',
+            baseBranchName: 'main',
+            number: 333,
+            labels: [],
+            files: [],
+          },
+          {
+            title: 'chore(main): release v9.0.1', // version from title differs from PR manifest
+            body: 'some content',
+            headBranchName:
+              'release-please--branches--main--changes--next--components--pkg4',
+            baseBranchName: 'main',
+            number: 444,
             labels: [],
             files: [],
           },
         ],
         []
       );
-      expect(pullRequests).lengthOf(2);
-      // title only edited for pkg2 thus should match version from PR title while pkg1 version should be a normal bump
-      expect(pullRequests[0].version?.toString()).to.eql('1.0.1');
-      expect(pullRequests[1].version?.toString()).to.eql('4.5.6-beta.1');
+      expect(pullRequests).lengthOf(4);
+      expect(pullRequests[0].version?.toString()).to.eql('6.7.9-alpha.1');
+      expect(pullRequests[1].version?.toString()).to.eql('7.8.9');
+      expect(pullRequests[2].version?.toString()).to.eql('8.9.0');
+      expect(pullRequests[3].version?.toString()).to.eql('9.0.1');
       sinon.assert.called(getFileContentsOnBranchStub);
       sinon.assert.called(addIssueLabelsStub);
-      expect(commented).to.be.true;
+      sinon.assert.called(findFilesByFilenameAndRefStub);
+      expect(commentCount).to.eql(4);
     });
 
     it('should always use PR title version when labelled as custom version', async () => {
@@ -2309,7 +2457,7 @@ describe('Manifest', () => {
           },
         },
       ]);
-      const config = {
+      const config: ManifestConfig = {
         'separate-pull-requests': true,
         packages: {
           'path/a': {
@@ -2430,7 +2578,7 @@ describe('Manifest', () => {
           },
         },
       ]);
-      const config = {
+      const config: ManifestConfig = {
         'separate-pull-requests': true,
         packages: {
           'path/a': {
@@ -2561,7 +2709,7 @@ describe('Manifest', () => {
           },
         },
       ]);
-      const config = {
+      const config: ManifestConfig = {
         'separate-pull-requests': true,
         packages: {
           'path/a': {
@@ -2653,7 +2801,7 @@ describe('Manifest', () => {
         },
       ]);
       mockTags(sandbox, github, []);
-      const config = {
+      const config: ManifestConfig = {
         'bootstrap-sha': 'cccccc',
         'separate-pull-requests': true,
         packages: {
@@ -2746,7 +2894,7 @@ describe('Manifest', () => {
         },
       ]);
       mockTags(sandbox, github, []);
-      const config = {
+      const config: ManifestConfig = {
         'last-release-sha': 'bbbbbb',
         'separate-pull-requests': true,
         packages: {
@@ -3002,7 +3150,7 @@ describe('Manifest', () => {
         },
       ]);
       mockTags(sandbox, github, []);
-      const config = {
+      const config: ManifestConfig = {
         packages: {
           'path/a': {
             'release-type': 'simple',

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -3437,6 +3437,7 @@ describe('Manifest', () => {
           plugins: ['node-workspace'],
         }
       );
+      mockPullRequests(github, []);
       sandbox.stub(manifest, 'buildPullRequests').resolves([]);
       const getLabelsStub = sandbox
         .stub(github, 'getLabels')

--- a/test/plugins/cargo-workspace.ts
+++ b/test/plugins/cargo-workspace.ts
@@ -15,7 +15,10 @@
 import {describe, it, afterEach, beforeEach} from 'mocha';
 import * as sinon from 'sinon';
 import {GitHub} from '../../src/github';
-import {CandidateReleasePullRequest} from '../../src/manifest';
+import {
+  CandidateReleasePullRequest,
+  DEFAULT_RELEASE_PLEASE_MANIFEST,
+} from '../../src/manifest';
 import {Update} from '../../src/update';
 import {
   buildGitHubFileContent,
@@ -65,17 +68,22 @@ describe('CargoWorkspace plugin', () => {
       repo: 'rust-test-repo',
       defaultBranch: 'main',
     });
-    plugin = new CargoWorkspace(github, 'main', {
-      'packages/rustA': {
-        releaseType: 'rust',
-      },
-      'packages/rustB': {
-        releaseType: 'rust',
-      },
-      'packages/rustC': {
-        releaseType: 'rust',
-      },
-    });
+    plugin = new CargoWorkspace(
+      github,
+      'main',
+      DEFAULT_RELEASE_PLEASE_MANIFEST,
+      {
+        'packages/rustA': {
+          releaseType: 'rust',
+        },
+        'packages/rustB': {
+          releaseType: 'rust',
+        },
+        'packages/rustC': {
+          releaseType: 'rust',
+        },
+      }
+    );
   });
   afterEach(() => {
     sandbox.restore();
@@ -114,14 +122,19 @@ describe('CargoWorkspace plugin', () => {
           ['Cargo.toml', '[workspace]\nmembers = ["packages/rustA"]'],
         ],
       });
-      plugin = new CargoWorkspace(github, 'main', {
-        python: {
-          releaseType: 'python',
-        },
-        'packages/rustA': {
-          releaseType: 'rust',
-        },
-      });
+      plugin = new CargoWorkspace(
+        github,
+        'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
+        {
+          python: {
+            releaseType: 'python',
+          },
+          'packages/rustA': {
+            releaseType: 'rust',
+          },
+        }
+      );
       sandbox
         .stub(github, 'findFilesByGlobAndRef')
         .withArgs('packages/rustA', 'main')
@@ -178,14 +191,19 @@ describe('CargoWorkspace plugin', () => {
         .resolves(['packages/rustA'])
         .withArgs('packages/rustD', 'main')
         .resolves(['packages/rustD']);
-      plugin = new CargoWorkspace(github, 'main', {
-        'packages/rustA': {
-          releaseType: 'rust',
-        },
-        'packages/rustD': {
-          releaseType: 'rust',
-        },
-      });
+      plugin = new CargoWorkspace(
+        github,
+        'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
+        {
+          'packages/rustA': {
+            releaseType: 'rust',
+          },
+          'packages/rustD': {
+            releaseType: 'rust',
+          },
+        }
+      );
       const newCandidates = await plugin.run(candidates);
       expect(newCandidates).lengthOf(1);
       const rustCandidate = newCandidates.find(
@@ -231,14 +249,19 @@ describe('CargoWorkspace plugin', () => {
         .stub(github, 'findFilesByGlobAndRef')
         .withArgs('packages/*', 'main')
         .resolves(['packages/rustA', 'packages/rustD']);
-      plugin = new CargoWorkspace(github, 'main', {
-        'packages/rustA': {
-          releaseType: 'rust',
-        },
-        'packages/rustD': {
-          releaseType: 'rust',
-        },
-      });
+      plugin = new CargoWorkspace(
+        github,
+        'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
+        {
+          'packages/rustA': {
+            releaseType: 'rust',
+          },
+          'packages/rustD': {
+            releaseType: 'rust',
+          },
+        }
+      );
       const newCandidates = await plugin.run(candidates);
       expect(newCandidates).lengthOf(1);
       const rustCandidate = newCandidates.find(
@@ -364,6 +387,7 @@ describe('CargoWorkspace plugin', () => {
       plugin = new CargoWorkspace(
         github,
         'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
         {
           'packages/rustA': {
             releaseType: 'rust',
@@ -534,14 +558,19 @@ describe('CargoWorkspace plugin', () => {
         .resolves(['packages/rustA'])
         .withArgs('packages/rustB', 'main')
         .resolves(['packages/rustB']);
-      plugin = new CargoWorkspace(github, 'main', {
-        'packages/rustA': {
-          releaseType: 'rust',
-        },
-        'packages/rustB': {
-          releaseType: 'rust',
-        },
-      });
+      plugin = new CargoWorkspace(
+        github,
+        'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
+        {
+          'packages/rustA': {
+            releaseType: 'rust',
+          },
+          'packages/rustB': {
+            releaseType: 'rust',
+          },
+        }
+      );
       await assert.rejects(
         async () => {
           await plugin.run(candidates);
@@ -589,14 +618,19 @@ describe('CargoWorkspace plugin', () => {
         .resolves(['packages/rustA'])
         .withArgs('packages/rustB', 'main')
         .resolves(['packages/rustB']);
-      plugin = new CargoWorkspace(github, 'main', {
-        'packages/rustA': {
-          releaseType: 'rust',
-        },
-        'packages/rustB': {
-          releaseType: 'rust',
-        },
-      });
+      plugin = new CargoWorkspace(
+        github,
+        'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
+        {
+          'packages/rustA': {
+            releaseType: 'rust',
+          },
+          'packages/rustB': {
+            releaseType: 'rust',
+          },
+        }
+      );
       await assert.rejects(
         async () => {
           await plugin.run(candidates);

--- a/test/plugins/compatibility/linked-versions-group-title.ts
+++ b/test/plugins/compatibility/linked-versions-group-title.ts
@@ -147,7 +147,7 @@ describe('Plugin compatibility', () => {
           groupPullRequestTitlePattern: 'chore: Release${component} ${version}',
         }
       );
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(1);
       const pullRequest = pullRequests[0];
       safeSnapshot(pullRequest.body.toString());

--- a/test/plugins/compatibility/linked-versions-workspace.ts
+++ b/test/plugins/compatibility/linked-versions-workspace.ts
@@ -164,7 +164,7 @@ describe('Plugin compatibility', () => {
           ],
         }
       );
-      const pullRequests = await manifest.buildPullRequests();
+      const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(1);
       const pullRequest = pullRequests[0];
       safeSnapshot(pullRequest.body.toString());

--- a/test/plugins/group-priority.ts
+++ b/test/plugins/group-priority.ts
@@ -15,7 +15,10 @@ import {describe, it, beforeEach} from 'mocha';
 import {expect} from 'chai';
 import {GitHub} from '../../src/github';
 import {GroupPriority} from '../../src/plugins/group-priority';
-import {CandidateReleasePullRequest} from '../../src/manifest';
+import {
+  CandidateReleasePullRequest,
+  DEFAULT_RELEASE_PLEASE_MANIFEST,
+} from '../../src/manifest';
 import {buildMockCandidatePullRequest} from '../helpers';
 
 describe('GroupPriority plugin', () => {
@@ -29,7 +32,13 @@ describe('GroupPriority plugin', () => {
   });
   describe('run', () => {
     it('prioritizes a group', async () => {
-      const plugin = new GroupPriority(github, 'main', {}, ['snapshot']);
+      const plugin = new GroupPriority(
+        github,
+        'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
+        {},
+        ['snapshot']
+      );
       const candidates: CandidateReleasePullRequest[] = [
         buildMockCandidatePullRequest('path1', 'java', '1.2.3-SNAPSHOT', {
           component: 'component1',
@@ -47,7 +56,13 @@ describe('GroupPriority plugin', () => {
       expect(newCandidates[0].path).to.eql('path1');
     });
     it('falls back to all pull requests if prioritized group not found', async () => {
-      const plugin = new GroupPriority(github, 'main', {}, ['snapshot']);
+      const plugin = new GroupPriority(
+        github,
+        'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
+        {},
+        ['snapshot']
+      );
       const candidates: CandidateReleasePullRequest[] = [
         buildMockCandidatePullRequest('path1', 'java', '1.2.3', {
           component: 'component1',

--- a/test/plugins/linked-versions.ts
+++ b/test/plugins/linked-versions.ts
@@ -166,7 +166,7 @@ describe('LinkedVersions plugin', () => {
         ],
       }
     );
-    const pullRequests = await manifest.buildPullRequests();
+    const pullRequests = await manifest.buildPullRequests([], []);
     expect(pullRequests).lengthOf(1);
     const pullRequest = pullRequests[0];
     const packageData2 = pullRequest.body.releaseData.find(
@@ -214,7 +214,7 @@ describe('LinkedVersions plugin', () => {
         ],
       }
     );
-    const pullRequests = await manifest.buildPullRequests();
+    const pullRequests = await manifest.buildPullRequests([], []);
     expect(pullRequests).lengthOf(2);
     const singlePullRequest = pullRequests[0];
     safeSnapshot(singlePullRequest.body.toString());
@@ -266,7 +266,7 @@ describe('LinkedVersions plugin', () => {
         ],
       }
     );
-    const pullRequests = await manifest.buildPullRequests();
+    const pullRequests = await manifest.buildPullRequests([], []);
     for (const pullRequest of pullRequests) {
       safeSnapshot(pullRequest.body.toString());
     }
@@ -315,7 +315,7 @@ describe('LinkedVersions plugin', () => {
         ],
       }
     );
-    const pullRequests = await manifest.buildPullRequests();
+    const pullRequests = await manifest.buildPullRequests([], []);
     expect(pullRequests).lengthOf(2);
     const groupPullRequest1 = pullRequests[1];
     const packageData1 = groupPullRequest1.body.releaseData.find(

--- a/test/plugins/maven-workspace.ts
+++ b/test/plugins/maven-workspace.ts
@@ -17,7 +17,10 @@ import * as sinon from 'sinon';
 import {MavenWorkspace} from '../../src/plugins/maven-workspace';
 import {GitHub} from '../../src/github';
 import {ManifestPlugin} from '../../src/plugin';
-import {CandidateReleasePullRequest} from '../../src/manifest';
+import {
+  CandidateReleasePullRequest,
+  DEFAULT_RELEASE_PLEASE_MANIFEST,
+} from '../../src/manifest';
 import {
   buildMockCandidatePullRequest,
   buildGitHubFileContent,
@@ -45,23 +48,28 @@ describe('MavenWorkspace plugin', () => {
       repo: 'maven-test-repo',
       defaultBranch: 'main',
     });
-    plugin = new MavenWorkspace(github, 'main', {
-      bom: {
-        releaseType: 'maven',
-      },
-      maven1: {
-        releaseType: 'maven',
-      },
-      maven2: {
-        releaseType: 'maven',
-      },
-      maven3: {
-        releaseType: 'maven',
-      },
-      maven4: {
-        releaseType: 'maven',
-      },
-    });
+    plugin = new MavenWorkspace(
+      github,
+      'main',
+      DEFAULT_RELEASE_PLEASE_MANIFEST,
+      {
+        bom: {
+          releaseType: 'maven',
+        },
+        maven1: {
+          releaseType: 'maven',
+        },
+        maven2: {
+          releaseType: 'maven',
+        },
+        maven3: {
+          releaseType: 'maven',
+        },
+        maven4: {
+          releaseType: 'maven',
+        },
+      }
+    );
   });
   afterEach(() => {
     sandbox.restore();
@@ -250,6 +258,7 @@ describe('MavenWorkspace plugin', () => {
       plugin = new MavenWorkspace(
         github,
         'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
         {
           bom: {
             releaseType: 'maven',
@@ -311,6 +320,7 @@ describe('MavenWorkspace plugin', () => {
       plugin = new MavenWorkspace(
         github,
         'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
         {
           bom: {
             component: 'my-bom',
@@ -405,23 +415,28 @@ describe('MavenWorkspace plugin', () => {
       safeSnapshot(await renderUpdate(github, 'main', bomUpdate));
     });
     it('skips updating manifest with snapshot versions', async () => {
-      plugin = new MavenWorkspace(github, 'main', {
-        bom: {
-          releaseType: 'maven',
-        },
-        maven1: {
-          releaseType: 'maven',
-        },
-        maven2: {
-          releaseType: 'maven',
-        },
-        maven3: {
-          releaseType: 'maven',
-        },
-        maven4: {
-          releaseType: 'maven',
-        },
-      });
+      plugin = new MavenWorkspace(
+        github,
+        'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
+        {
+          bom: {
+            releaseType: 'maven',
+          },
+          maven1: {
+            releaseType: 'maven',
+          },
+          maven2: {
+            releaseType: 'maven',
+          },
+          maven3: {
+            releaseType: 'maven',
+          },
+          maven4: {
+            releaseType: 'maven',
+          },
+        }
+      );
       sandbox
         .stub(github, 'findFilesByFilenameAndRef')
         .withArgs('pom.xml', 'main')

--- a/test/plugins/merge.ts
+++ b/test/plugins/merge.ts
@@ -15,7 +15,10 @@ import {describe, it, afterEach, beforeEach} from 'mocha';
 import * as sinon from 'sinon';
 import {GitHub} from '../../src/github';
 import {Merge} from '../../src/plugins/merge';
-import {CandidateReleasePullRequest} from '../../src/manifest';
+import {
+  CandidateReleasePullRequest,
+  DEFAULT_RELEASE_PLEASE_MANIFEST,
+} from '../../src/manifest';
 import {expect} from 'chai';
 import {
   buildMockCandidatePullRequest,
@@ -43,7 +46,12 @@ describe('Merge plugin', () => {
   describe('run', () => {
     it('ignores no pull requests', async () => {
       const candidates: CandidateReleasePullRequest[] = [];
-      const plugin = new Merge(github, 'main', {});
+      const plugin = new Merge(
+        github,
+        'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
+        {}
+      );
       const newCandidates = await plugin.run(candidates);
       expect(newCandidates).lengthOf(0);
     });
@@ -52,7 +60,12 @@ describe('Merge plugin', () => {
       const candidates: CandidateReleasePullRequest[] = [
         buildMockCandidatePullRequest('python', 'python', '1.0.0'),
       ];
-      const plugin = new Merge(github, 'main', {});
+      const plugin = new Merge(
+        github,
+        'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
+        {}
+      );
       const newCandidates = await plugin.run(candidates);
       expect(newCandidates).lengthOf(1);
       expect(newCandidates[0].pullRequest.title.toString()).to.eql(
@@ -88,7 +101,12 @@ describe('Merge plugin', () => {
           ],
         }),
       ];
-      const plugin = new Merge(github, 'main', {});
+      const plugin = new Merge(
+        github,
+        'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
+        {}
+      );
       const newCandidates = await plugin.run(candidates);
       expect(newCandidates).lengthOf(1);
       const candidate = newCandidates[0];
@@ -131,7 +149,12 @@ describe('Merge plugin', () => {
           draft: true,
         }),
       ];
-      const plugin = new Merge(github, 'main', {});
+      const plugin = new Merge(
+        github,
+        'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
+        {}
+      );
       const newCandidates = await plugin.run(candidates);
       expect(newCandidates).lengthOf(1);
       const candidate = newCandidates[0];
@@ -173,7 +196,12 @@ describe('Merge plugin', () => {
           labels: ['label-a', 'label-c'],
         }),
       ];
-      const plugin = new Merge(github, 'main', {});
+      const plugin = new Merge(
+        github,
+        'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
+        {}
+      );
       const newCandidates = await plugin.run(candidates);
       expect(newCandidates).lengthOf(1);
       const candidate = newCandidates[0]!;

--- a/test/plugins/node-workspace.ts
+++ b/test/plugins/node-workspace.ts
@@ -16,7 +16,10 @@ import {describe, it, afterEach, beforeEach} from 'mocha';
 import * as sinon from 'sinon';
 import {GitHub} from '../../src/github';
 import {NodeWorkspace} from '../../src/plugins/node-workspace';
-import {CandidateReleasePullRequest} from '../../src/manifest';
+import {
+  CandidateReleasePullRequest,
+  DEFAULT_RELEASE_PLEASE_MANIFEST,
+} from '../../src/manifest';
 import {expect} from 'chai';
 import {Version} from '../../src/version';
 import {Update} from '../../src/update';
@@ -89,23 +92,28 @@ describe('NodeWorkspace plugin', () => {
       repo: 'node-test-repo',
       defaultBranch: 'main',
     });
-    plugin = new NodeWorkspace(github, 'main', {
-      node1: {
-        releaseType: 'node',
-      },
-      node2: {
-        releaseType: 'node',
-      },
-      node3: {
-        releaseType: 'node',
-      },
-      node4: {
-        releaseType: 'node',
-      },
-      node5: {
-        releaseType: 'node',
-      },
-    });
+    plugin = new NodeWorkspace(
+      github,
+      'main',
+      DEFAULT_RELEASE_PLEASE_MANIFEST,
+      {
+        node1: {
+          releaseType: 'node',
+        },
+        node2: {
+          releaseType: 'node',
+        },
+        node3: {
+          releaseType: 'node',
+        },
+        node4: {
+          releaseType: 'node',
+        },
+        node5: {
+          releaseType: 'node',
+        },
+      }
+    );
   });
   afterEach(() => {
     sandbox.restore();
@@ -128,14 +136,19 @@ describe('NodeWorkspace plugin', () => {
           ],
         }),
       ];
-      plugin = new NodeWorkspace(github, 'main', {
-        python: {
-          releaseType: 'python',
-        },
-        node1: {
-          releaseType: 'node',
-        },
-      });
+      plugin = new NodeWorkspace(
+        github,
+        'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
+        {
+          python: {
+            releaseType: 'python',
+          },
+          node1: {
+            releaseType: 'node',
+          },
+        }
+      );
       const newCandidates = await plugin.run(candidates);
       expect(newCandidates).lengthOf(2);
       const nodeCandidate = newCandidates.find(
@@ -164,10 +177,15 @@ describe('NodeWorkspace plugin', () => {
           ],
         }),
       ];
-      plugin = new NodeWorkspace(github, 'main', {
-        plugin1: {releaseType: 'node'},
-        node1: {releaseType: 'node'},
-      });
+      plugin = new NodeWorkspace(
+        github,
+        'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
+        {
+          plugin1: {releaseType: 'node'},
+          node1: {releaseType: 'node'},
+        }
+      );
       const newCandidates = await plugin.run(candidates);
       expect(newCandidates).lengthOf(1);
       const nodeCandidate = newCandidates.find(
@@ -212,17 +230,22 @@ describe('NodeWorkspace plugin', () => {
         flatten: false,
         targetBranch: 'main',
       });
-      plugin = new NodeWorkspace(github, 'main', {
-        '.': {
-          releaseType: 'node',
-        },
-        node1: {
-          releaseType: 'node',
-        },
-        node4: {
-          releaseType: 'node',
-        },
-      });
+      plugin = new NodeWorkspace(
+        github,
+        'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
+        {
+          '.': {
+            releaseType: 'node',
+          },
+          node1: {
+            releaseType: 'node',
+          },
+          node4: {
+            releaseType: 'node',
+          },
+        }
+      );
       const newCandidates = await plugin.run(candidates);
       expect(newCandidates).lengthOf(1);
       const nodeCandidate = newCandidates.find(
@@ -388,14 +411,19 @@ describe('NodeWorkspace plugin', () => {
         flatten: false,
         targetBranch: 'main',
       });
-      plugin = new NodeWorkspace(github, 'main', {
-        node1: {
-          releaseType: 'node',
-        },
-        plugin1: {
-          releaseType: 'node',
-        },
-      });
+      plugin = new NodeWorkspace(
+        github,
+        'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
+        {
+          node1: {
+            releaseType: 'node',
+          },
+          plugin1: {
+            releaseType: 'node',
+          },
+        }
+      );
       const newCandidates = await plugin.run(candidates);
       expect(newCandidates).lengthOf(1);
       const nodeCandidate = newCandidates.find(

--- a/test/plugins/sentence-case.ts
+++ b/test/plugins/sentence-case.ts
@@ -17,6 +17,7 @@ import {expect} from 'chai';
 
 import {GitHub} from '../../src/github';
 import {buildMockConventionalCommit} from '../helpers';
+import {DEFAULT_RELEASE_PLEASE_MANIFEST} from '../../src/manifest';
 
 describe('SentenceCase Plugin', () => {
   let github: GitHub;
@@ -29,7 +30,12 @@ describe('SentenceCase Plugin', () => {
   });
   describe('processCommits', () => {
     it('converts description to sentence case', async () => {
-      const plugin = new SentenceCase(github, 'main', {});
+      const plugin = new SentenceCase(
+        github,
+        'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
+        {}
+      );
       const commits = await plugin.processCommits([
         ...buildMockConventionalCommit('fix: hello world'),
         ...buildMockConventionalCommit('fix: Goodnight moon'),
@@ -38,7 +44,12 @@ describe('SentenceCase Plugin', () => {
       expect(commits[1].message).to.equal('fix: Goodnight moon');
     });
     it('leaves reserved words lowercase', async () => {
-      const plugin = new SentenceCase(github, 'main', {});
+      const plugin = new SentenceCase(
+        github,
+        'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
+        {}
+      );
       const commits = await plugin.processCommits([
         ...buildMockConventionalCommit('feat: gRPC can now handle proxies'),
         ...buildMockConventionalCommit('fix: npm now rocks'),
@@ -47,7 +58,12 @@ describe('SentenceCase Plugin', () => {
       expect(commits[1].message).to.equal('fix: npm now rocks');
     });
     it('handles sentences with now breaks', async () => {
-      const plugin = new SentenceCase(github, 'main', {});
+      const plugin = new SentenceCase(
+        github,
+        'main',
+        DEFAULT_RELEASE_PLEASE_MANIFEST,
+        {}
+      );
       const commits = await plugin.processCommits([
         ...buildMockConventionalCommit('feat: beep-boop-hello'),
         ...buildMockConventionalCommit('fix:log4j.foo.bar'),
@@ -57,7 +73,13 @@ describe('SentenceCase Plugin', () => {
     });
   });
   it('allows a custom list of specialWords to be provided', async () => {
-    const plugin = new SentenceCase(github, 'main', {}, ['hello']);
+    const plugin = new SentenceCase(
+      github,
+      'main',
+      DEFAULT_RELEASE_PLEASE_MANIFEST,
+      {},
+      ['hello']
+    );
     const commits = await plugin.processCommits([
       ...buildMockConventionalCommit('fix: hello world'),
       ...buildMockConventionalCommit('fix: Goodnight moon'),
@@ -66,7 +88,13 @@ describe('SentenceCase Plugin', () => {
     expect(commits[1].message).to.equal('fix: Goodnight moon');
   });
   it('handles subject with multiple : characters', async () => {
-    const plugin = new SentenceCase(github, 'main', {}, []);
+    const plugin = new SentenceCase(
+      github,
+      'main',
+      DEFAULT_RELEASE_PLEASE_MANIFEST,
+      {},
+      []
+    );
     const commits = await plugin.processCommits([
       ...buildMockConventionalCommit('abc123'),
       ...buildMockConventionalCommit('fix: hello world:goodnight moon'),
@@ -74,7 +102,13 @@ describe('SentenceCase Plugin', () => {
     expect(commits[0].message).to.equal('fix: Hello world:goodnight moon');
   });
   it('handles commit with no :', async () => {
-    const plugin = new SentenceCase(github, 'main', {}, []);
+    const plugin = new SentenceCase(
+      github,
+      'main',
+      DEFAULT_RELEASE_PLEASE_MANIFEST,
+      {},
+      []
+    );
     const commits = await plugin.processCommits([
       ...buildMockConventionalCommit('hello world goodnight moon'),
     ]);

--- a/test/strategies/base.ts
+++ b/test/strategies/base.ts
@@ -31,6 +31,7 @@ import {GenericXml} from '../../src/updaters/generic-xml';
 import {PomXml} from '../../src/updaters/java/pom-xml';
 import {GenericYaml} from '../../src/updaters/generic-yaml';
 import {GenericToml} from '../../src/updaters/generic-toml';
+import {DEFAULT_RELEASE_PLEASE_MANIFEST} from '../../src/manifest';
 
 const sandbox = sinon.createSandbox();
 
@@ -59,7 +60,10 @@ describe('Strategy', () => {
         github,
         component: 'google-cloud-automl',
       });
-      const pullRequest = await strategy.buildReleasePullRequest([]);
+      const pullRequest = await strategy.buildReleasePullRequest({
+        commits: [],
+        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
+      });
       expect(pullRequest).to.be.undefined;
     });
     it('allows overriding initial version', async () => {
@@ -71,7 +75,10 @@ describe('Strategy', () => {
       const commits = buildMockConventionalCommit(
         'chore: initial commit\n\nRelease-As: 2.3.4'
       );
-      const pullRequest = await strategy.buildReleasePullRequest(commits);
+      const pullRequest = await strategy.buildReleasePullRequest({
+        commits,
+        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
+      });
       expect(pullRequest).to.not.be.undefined;
       expect(pullRequest?.version?.toString()).to.eql('2.3.4');
       snapshot(dateSafe(pullRequest!.body.toString()));
@@ -84,7 +91,10 @@ describe('Strategy', () => {
         initialVersion: '0.1.0',
       });
       const commits = buildMockConventionalCommit('feat: initial commit');
-      const pullRequest = await strategy.buildReleasePullRequest(commits);
+      const pullRequest = await strategy.buildReleasePullRequest({
+        commits,
+        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
+      });
       expect(pullRequest).to.not.be.undefined;
       expect(pullRequest?.version?.toString()).to.eql('0.1.0');
       snapshot(dateSafe(pullRequest!.body.toString()));
@@ -104,10 +114,11 @@ describe('Strategy', () => {
           '/3.java',
         ],
       });
-      const pullRequest = await strategy.buildReleasePullRequest(
-        buildMockConventionalCommit('fix: a bugfix'),
-        undefined
-      );
+      const pullRequest = await strategy.buildReleasePullRequest({
+        commits: buildMockConventionalCommit('fix: a bugfix'),
+        latestRelease: undefined,
+        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
+      });
       expect(pullRequest).to.exist;
       expect(pullRequest?.updates).to.be.an('array');
       expect(pullRequest?.updates.map(update => update.path))
@@ -129,10 +140,11 @@ describe('Strategy', () => {
         component: 'google-cloud-automl',
         extraFiles: ['0', {type: 'json', path: '/3.json', jsonpath: '$.foo'}],
       });
-      const pullRequest = await strategy.buildReleasePullRequest(
-        buildMockConventionalCommit('fix: a bugfix'),
-        undefined
-      );
+      const pullRequest = await strategy.buildReleasePullRequest({
+        commits: buildMockConventionalCommit('fix: a bugfix'),
+        latestRelease: undefined,
+        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
+      });
       expect(pullRequest).to.exist;
       const updates = pullRequest?.updates;
       expect(updates).to.be.an('array');
@@ -146,10 +158,11 @@ describe('Strategy', () => {
         component: 'google-cloud-automl',
         extraFiles: ['0', {type: 'yaml', path: '/3.yaml', jsonpath: '$.foo'}],
       });
-      const pullRequest = await strategy.buildReleasePullRequest(
-        buildMockConventionalCommit('fix: a bugfix'),
-        undefined
-      );
+      const pullRequest = await strategy.buildReleasePullRequest({
+        commits: buildMockConventionalCommit('fix: a bugfix'),
+        latestRelease: undefined,
+        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
+      });
       expect(pullRequest).to.exist;
       const updates = pullRequest?.updates;
       expect(updates).to.be.an('array');
@@ -163,10 +176,11 @@ describe('Strategy', () => {
         component: 'google-cloud-automl',
         extraFiles: ['0', {type: 'toml', path: '/3.toml', jsonpath: '$.foo'}],
       });
-      const pullRequest = await strategy.buildReleasePullRequest(
-        buildMockConventionalCommit('fix: a bugfix'),
-        undefined
-      );
+      const pullRequest = await strategy.buildReleasePullRequest({
+        commits: buildMockConventionalCommit('fix: a bugfix'),
+        latestRelease: undefined,
+        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
+      });
       expect(pullRequest).to.exist;
       const updates = pullRequest?.updates;
       expect(updates).to.be.an('array');
@@ -180,10 +194,11 @@ describe('Strategy', () => {
         component: 'google-cloud-automl',
         extraFiles: ['0', {type: 'xml', path: '/3.xml', xpath: '$.foo'}],
       });
-      const pullRequest = await strategy.buildReleasePullRequest(
-        buildMockConventionalCommit('fix: a bugfix'),
-        undefined
-      );
+      const pullRequest = await strategy.buildReleasePullRequest({
+        commits: buildMockConventionalCommit('fix: a bugfix'),
+        latestRelease: undefined,
+        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
+      });
       expect(pullRequest).to.exist;
       const updates = pullRequest?.updates;
       expect(updates).to.be.an('array');
@@ -197,10 +212,11 @@ describe('Strategy', () => {
         component: 'google-cloud-automl',
         extraFiles: ['0', {type: 'pom', path: '/3.xml'}],
       });
-      const pullRequest = await strategy.buildReleasePullRequest(
-        buildMockConventionalCommit('fix: a bugfix'),
-        undefined
-      );
+      const pullRequest = await strategy.buildReleasePullRequest({
+        commits: buildMockConventionalCommit('fix: a bugfix'),
+        latestRelease: undefined,
+        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
+      });
       expect(pullRequest).to.exist;
       const updates = pullRequest?.updates;
       expect(updates).to.be.an('array');
@@ -225,10 +241,11 @@ describe('Strategy', () => {
           },
         ],
       });
-      const pullRequest = await strategy.buildReleasePullRequest(
-        buildMockConventionalCommit('fix: a bugfix'),
-        undefined
-      );
+      const pullRequest = await strategy.buildReleasePullRequest({
+        commits: buildMockConventionalCommit('fix: a bugfix'),
+        latestRelease: undefined,
+        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
+      });
       expect(pullRequest).to.exist;
       const updates = pullRequest?.updates;
       expect(updates).to.be.an('array');
@@ -244,7 +261,10 @@ describe('Strategy', () => {
         changelogHost: 'https://example.com',
       });
       const commits = buildMockConventionalCommit('fix: a bugfix');
-      const pullRequest = await strategy.buildReleasePullRequest(commits);
+      const pullRequest = await strategy.buildReleasePullRequest({
+        commits,
+        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
+      });
       expect(pullRequest).to.exist;
       expect(pullRequest?.body.toString()).to.have.string(
         'https://example.com'
@@ -271,10 +291,11 @@ describe('Strategy', () => {
             component: 'google-cloud-automl',
             extraFiles: [file],
           });
-          await strategy.buildReleasePullRequest(
-            buildMockConventionalCommit('fix: a bugfix'),
-            undefined
-          );
+          await strategy.buildReleasePullRequest({
+            commits: buildMockConventionalCommit('fix: a bugfix'),
+            latestRelease: undefined,
+            manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
+          });
           expect.fail(`expected [addPath] to reject path: ${file}`);
         } catch (err) {
           expect(err).to.be.instanceof(Error);
@@ -291,10 +312,11 @@ describe('Strategy', () => {
         component: 'google-cloud-automl',
         extraLabels: ['foo', 'bar'],
       });
-      const pullRequest = await strategy.buildReleasePullRequest(
-        buildMockConventionalCommit('fix: a bugfix'),
-        undefined
-      );
+      const pullRequest = await strategy.buildReleasePullRequest({
+        commits: buildMockConventionalCommit('fix: a bugfix'),
+        latestRelease: undefined,
+        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
+      });
       expect(pullRequest).to.exist;
       expect(pullRequest?.labels).to.eql(['foo', 'bar']);
     });

--- a/test/strategies/base.ts
+++ b/test/strategies/base.ts
@@ -62,7 +62,6 @@ describe('Strategy', () => {
       });
       const pullRequest = await strategy.buildReleasePullRequest({
         commits: [],
-        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
       });
       expect(pullRequest).to.be.undefined;
     });
@@ -77,7 +76,6 @@ describe('Strategy', () => {
       );
       const pullRequest = await strategy.buildReleasePullRequest({
         commits,
-        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
       });
       expect(pullRequest).to.not.be.undefined;
       expect(pullRequest?.version?.toString()).to.eql('2.3.4');
@@ -93,7 +91,6 @@ describe('Strategy', () => {
       const commits = buildMockConventionalCommit('feat: initial commit');
       const pullRequest = await strategy.buildReleasePullRequest({
         commits,
-        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
       });
       expect(pullRequest).to.not.be.undefined;
       expect(pullRequest?.version?.toString()).to.eql('0.1.0');
@@ -117,7 +114,6 @@ describe('Strategy', () => {
       const pullRequest = await strategy.buildReleasePullRequest({
         commits: buildMockConventionalCommit('fix: a bugfix'),
         latestRelease: undefined,
-        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
       });
       expect(pullRequest).to.exist;
       expect(pullRequest?.updates).to.be.an('array');
@@ -143,7 +139,6 @@ describe('Strategy', () => {
       const pullRequest = await strategy.buildReleasePullRequest({
         commits: buildMockConventionalCommit('fix: a bugfix'),
         latestRelease: undefined,
-        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
       });
       expect(pullRequest).to.exist;
       const updates = pullRequest?.updates;
@@ -161,7 +156,6 @@ describe('Strategy', () => {
       const pullRequest = await strategy.buildReleasePullRequest({
         commits: buildMockConventionalCommit('fix: a bugfix'),
         latestRelease: undefined,
-        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
       });
       expect(pullRequest).to.exist;
       const updates = pullRequest?.updates;
@@ -179,7 +173,6 @@ describe('Strategy', () => {
       const pullRequest = await strategy.buildReleasePullRequest({
         commits: buildMockConventionalCommit('fix: a bugfix'),
         latestRelease: undefined,
-        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
       });
       expect(pullRequest).to.exist;
       const updates = pullRequest?.updates;
@@ -197,7 +190,6 @@ describe('Strategy', () => {
       const pullRequest = await strategy.buildReleasePullRequest({
         commits: buildMockConventionalCommit('fix: a bugfix'),
         latestRelease: undefined,
-        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
       });
       expect(pullRequest).to.exist;
       const updates = pullRequest?.updates;
@@ -215,7 +207,6 @@ describe('Strategy', () => {
       const pullRequest = await strategy.buildReleasePullRequest({
         commits: buildMockConventionalCommit('fix: a bugfix'),
         latestRelease: undefined,
-        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
       });
       expect(pullRequest).to.exist;
       const updates = pullRequest?.updates;
@@ -244,7 +235,6 @@ describe('Strategy', () => {
       const pullRequest = await strategy.buildReleasePullRequest({
         commits: buildMockConventionalCommit('fix: a bugfix'),
         latestRelease: undefined,
-        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
       });
       expect(pullRequest).to.exist;
       const updates = pullRequest?.updates;
@@ -263,7 +253,6 @@ describe('Strategy', () => {
       const commits = buildMockConventionalCommit('fix: a bugfix');
       const pullRequest = await strategy.buildReleasePullRequest({
         commits,
-        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
       });
       expect(pullRequest).to.exist;
       expect(pullRequest?.body.toString()).to.have.string(
@@ -294,7 +283,6 @@ describe('Strategy', () => {
           await strategy.buildReleasePullRequest({
             commits: buildMockConventionalCommit('fix: a bugfix'),
             latestRelease: undefined,
-            manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
           });
           expect.fail(`expected [addPath] to reject path: ${file}`);
         } catch (err) {
@@ -315,7 +303,6 @@ describe('Strategy', () => {
       const pullRequest = await strategy.buildReleasePullRequest({
         commits: buildMockConventionalCommit('fix: a bugfix'),
         latestRelease: undefined,
-        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
       });
       expect(pullRequest).to.exist;
       expect(pullRequest?.labels).to.eql(['foo', 'bar']);

--- a/test/strategies/base.ts
+++ b/test/strategies/base.ts
@@ -31,7 +31,6 @@ import {GenericXml} from '../../src/updaters/generic-xml';
 import {PomXml} from '../../src/updaters/java/pom-xml';
 import {GenericYaml} from '../../src/updaters/generic-yaml';
 import {GenericToml} from '../../src/updaters/generic-toml';
-import {DEFAULT_RELEASE_PLEASE_MANIFEST} from '../../src/manifest';
 
 const sandbox = sinon.createSandbox();
 

--- a/test/strategies/dart.ts
+++ b/test/strategies/dart.ts
@@ -27,6 +27,7 @@ import {TagName} from '../../src/util/tag-name';
 import {expect} from 'chai';
 import {Changelog} from '../../src/updaters/changelog';
 import {PubspecYaml} from '../../src/updaters/dart/pubspec-yaml';
+import {DEFAULT_RELEASE_PLEASE_MANIFEST} from '../../src/manifest';
 
 nock.disableNetConnect();
 const sandbox = sinon.createSandbox();
@@ -60,10 +61,10 @@ describe('Dart', () => {
       });
       sandbox.stub(github, 'findFilesByFilenameAndRef').resolves([]);
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
+      const release = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(release?.version?.toString()).to.eql(expectedVersion);
     });
     it('builds a release pull request', async () => {
@@ -79,10 +80,10 @@ describe('Dart', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const release = await strategy.buildReleasePullRequest(
+      const release = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(release?.version?.toString()).to.eql(expectedVersion);
     });
     it('detects a default component', async () => {
@@ -108,10 +109,10 @@ describe('Dart', () => {
       getFileContentsStub
         .withArgs('pubspec.yaml', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'pubspec.yaml'));
-      const pullRequest = await strategy.buildReleasePullRequest(
+      const pullRequest = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(pullRequest?.version?.toString()).to.eql(expectedVersion);
     });
   });
@@ -133,10 +134,10 @@ describe('Dart', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const pullRequest = await strategy.buildReleasePullRequest(
+      const pullRequest = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       const updates = pullRequest!.updates;
       expect(updates).lengthOf(2);
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);

--- a/test/strategies/dart.ts
+++ b/test/strategies/dart.ts
@@ -27,7 +27,6 @@ import {TagName} from '../../src/util/tag-name';
 import {expect} from 'chai';
 import {Changelog} from '../../src/updaters/changelog';
 import {PubspecYaml} from '../../src/updaters/dart/pubspec-yaml';
-import {DEFAULT_RELEASE_PLEASE_MANIFEST} from '../../src/manifest';
 
 nock.disableNetConnect();
 const sandbox = sinon.createSandbox();

--- a/test/strategies/dotnet-yoshi.ts
+++ b/test/strategies/dotnet-yoshi.ts
@@ -28,6 +28,7 @@ import {TagName} from '../../src/util/tag-name';
 import {Changelog} from '../../src/updaters/changelog';
 import {PullRequestBody} from '../../src/util/pull-request-body';
 import {Apis} from '../../src/updaters/dotnet/apis';
+import {DEFAULT_RELEASE_PLEASE_MANIFEST} from '../../src/manifest';
 
 const sandbox = sinon.createSandbox();
 const fixturesPath = './test/fixtures/strategies/dotnet-yoshi';
@@ -71,10 +72,10 @@ describe('DotnetYoshi', () => {
         component: 'Google.Cloud.SecurityCenter.V1',
       });
       const latestRelease = undefined;
-      const pullRequest = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const pullRequest = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(pullRequest!.version?.toString()).to.eql(expectedVersion);
       expect(pullRequest?.title.toString()).to.eql(expectedTitle);
       safeSnapshot(pullRequest!.body.toString());
@@ -93,10 +94,10 @@ describe('DotnetYoshi', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const pullRequest = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const pullRequest = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(pullRequest!.version?.toString()).to.eql(expectedVersion);
       expect(pullRequest?.title.toString()).to.eql(expectedTitle);
       safeSnapshot(pullRequest!.body.toString());
@@ -115,10 +116,10 @@ describe('DotnetYoshi', () => {
         .withArgs('apis/apis.json', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'apis.json'));
       const latestRelease = undefined;
-      const pullRequest = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const pullRequest = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = pullRequest!.updates;
       expect(updates).lengthOf(2);
       const changelogUpdate = assertHasUpdate(
@@ -141,10 +142,10 @@ describe('DotnetYoshi', () => {
         .withArgs('apis/apis.json', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'apis.json'));
       const latestRelease = undefined;
-      const pullRequest = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const pullRequest = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = pullRequest!.updates;
       expect(updates).lengthOf(1);
       assertNoHasUpdate(

--- a/test/strategies/dotnet-yoshi.ts
+++ b/test/strategies/dotnet-yoshi.ts
@@ -28,7 +28,6 @@ import {TagName} from '../../src/util/tag-name';
 import {Changelog} from '../../src/updaters/changelog';
 import {PullRequestBody} from '../../src/util/pull-request-body';
 import {Apis} from '../../src/updaters/dotnet/apis';
-import {DEFAULT_RELEASE_PLEASE_MANIFEST} from '../../src/manifest';
 
 const sandbox = sinon.createSandbox();
 const fixturesPath = './test/fixtures/strategies/dotnet-yoshi';

--- a/test/strategies/elixir.ts
+++ b/test/strategies/elixir.ts
@@ -23,7 +23,6 @@ import {TagName} from '../../src/util/tag-name';
 import {expect} from 'chai';
 import {Changelog} from '../../src/updaters/changelog';
 import {ElixirMixExs} from '../../src/updaters/elixir/elixir-mix-exs';
-import {DEFAULT_RELEASE_PLEASE_MANIFEST} from '../../src/manifest';
 
 nock.disableNetConnect();
 const sandbox = sinon.createSandbox();

--- a/test/strategies/elixir.ts
+++ b/test/strategies/elixir.ts
@@ -23,6 +23,7 @@ import {TagName} from '../../src/util/tag-name';
 import {expect} from 'chai';
 import {Changelog} from '../../src/updaters/changelog';
 import {ElixirMixExs} from '../../src/updaters/elixir/elixir-mix-exs';
+import {DEFAULT_RELEASE_PLEASE_MANIFEST} from '../../src/manifest';
 
 nock.disableNetConnect();
 const sandbox = sinon.createSandbox();
@@ -54,10 +55,10 @@ describe('Elixir', () => {
       });
       sandbox.stub(github, 'findFilesByFilenameAndRef').resolves([]);
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
+      const release = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(release?.version?.toString()).to.eql(expectedVersion);
     });
     it('builds a release pull request', async () => {
@@ -72,10 +73,10 @@ describe('Elixir', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const release = await strategy.buildReleasePullRequest(
+      const release = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(release?.version?.toString()).to.eql(expectedVersion);
     });
   });
@@ -87,10 +88,10 @@ describe('Elixir', () => {
         component: 'google-cloud-automl',
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
+      const release = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       assertHasUpdate(updates, 'mix.exs', ElixirMixExs);

--- a/test/strategies/expo.ts
+++ b/test/strategies/expo.ts
@@ -74,10 +74,10 @@ describe('Expo', () => {
         packageName: 'google-cloud-automl',
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
+      const release = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
 
@@ -103,10 +103,10 @@ describe('Expo', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const pullRequest = await strategy.buildReleasePullRequest(
+      const pullRequest = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(pullRequest!.version?.toString()).to.eql(expectedVersion);
     });
 
@@ -135,10 +135,10 @@ describe('Expo', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const pullRequest = await strategy.buildReleasePullRequest(
+      const pullRequest = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(pullRequest!.version?.toString()).to.eql(expectedVersion);
     });
 
@@ -168,10 +168,10 @@ describe('Expo', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const pullRequest = await strategy.buildReleasePullRequest(
+      const pullRequest = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(pullRequest!.version?.toString()).to.eql(expectedVersion);
     });
   });
@@ -194,10 +194,10 @@ describe('Expo', () => {
       });
       sandbox.stub(github, 'findFilesByFilenameAndRef').resolves([]);
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
+      const release = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       const updates = release!.updates;
 
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);

--- a/test/strategies/go-yoshi.ts
+++ b/test/strategies/go-yoshi.ts
@@ -56,10 +56,10 @@ describe('GoYoshi', () => {
         component: 'iam',
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(release?.version?.toString()).to.eql(expectedVersion);
     });
     it('returns release PR changes with semver patch bump', async () => {
@@ -74,10 +74,10 @@ describe('GoYoshi', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(release?.version?.toString()).to.eql(expectedVersion);
     });
   });
@@ -89,10 +89,10 @@ describe('GoYoshi', () => {
         component: 'iam',
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGES.md', Changelog);
       assertHasUpdate(updates, 'internal/version.go', VersionGo);
@@ -115,7 +115,7 @@ describe('GoYoshi', () => {
         ...buildMockConventionalCommit('fix(logging): some logging fix'),
         ...buildMockConventionalCommit('feat: some generic feature'),
       ];
-      const pullRequest = await strategy.buildReleasePullRequest(commits);
+      const pullRequest = await strategy.buildReleasePullRequest({commits});
       const pullRequestBody = pullRequest!.body.toString();
       expect(pullRequestBody).to.not.include('logging');
       snapshot(dateSafe(pullRequestBody));
@@ -138,7 +138,7 @@ describe('GoYoshi', () => {
         ]),
         ...buildMockConventionalCommit('feat: some generic feature'),
       ];
-      const pullRequest = await strategy.buildReleasePullRequest(commits);
+      const pullRequest = await strategy.buildReleasePullRequest({commits});
       const pullRequestBody = pullRequest!.body.toString();
       expect(pullRequestBody).to.not.include('access');
       expect(pullRequestBody).to.include('iam');
@@ -169,7 +169,7 @@ describe('GoYoshi', () => {
           'feat(all): auto-regenerate discovery clients (#1278)'
         ),
       ];
-      const pullRequest = await strategy.buildReleasePullRequest(commits);
+      const pullRequest = await strategy.buildReleasePullRequest({commits});
       const pullRequestBody = pullRequest!.body.toString();
       snapshot(dateSafe(pullRequestBody));
     });

--- a/test/strategies/go.ts
+++ b/test/strategies/go.ts
@@ -56,10 +56,10 @@ describe('Go', () => {
         component: 'google-cloud-automl',
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
     it('returns release PR changes with semver patch bump', async () => {
@@ -74,10 +74,10 @@ describe('Go', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
   });
@@ -89,10 +89,10 @@ describe('Go', () => {
         component: 'google-cloud-automl',
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
     });

--- a/test/strategies/helm.ts
+++ b/test/strategies/helm.ts
@@ -59,10 +59,10 @@ describe('Helm', () => {
         packageName: 'google-cloud-automl',
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
+      const release = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
     it('builds a release pull request', async () => {
@@ -78,10 +78,10 @@ describe('Helm', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const pullRequest = await strategy.buildReleasePullRequest(
+      const pullRequest = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(pullRequest!.version?.toString()).to.eql(expectedVersion);
     });
     it('detects a default component', async () => {
@@ -102,10 +102,10 @@ describe('Helm', () => {
       getFileContentsStub
         .withArgs('Chart.yaml', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'Chart.yaml'));
-      const pullRequest = await strategy.buildReleasePullRequest(
+      const pullRequest = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(pullRequest!.version?.toString()).to.eql(expectedVersion);
     });
   });
@@ -118,10 +118,10 @@ describe('Helm', () => {
         packageName: 'google-cloud-automl',
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
+      const release = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       const updates = release!.updates;
       expect(updates).lengthOf(2);
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);

--- a/test/strategies/java-yoshi-mono-repo.ts
+++ b/test/strategies/java-yoshi-mono-repo.ts
@@ -80,10 +80,10 @@ describe('JavaYoshiMonoRepo', () => {
         .withArgs('versions.txt', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'versions.txt'));
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
     it('returns release PR changes with semver patch bump', async () => {
@@ -106,10 +106,10 @@ describe('JavaYoshiMonoRepo', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
     it('returns a snapshot bump PR', async () => {
@@ -134,10 +134,10 @@ describe('JavaYoshiMonoRepo', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
     it('handles promotion to 1.0.0', async () => {
@@ -170,10 +170,10 @@ describe('JavaYoshiMonoRepo', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const releasePullRequest = await strategy.buildReleasePullRequest(
-        commits,
-        latestRelease
-      );
+      const releasePullRequest = await strategy.buildReleasePullRequest({
+        commits: commits,
+        latestRelease,
+      });
       expect(releasePullRequest!.version?.toString()).to.eql(expectedVersion);
       const update = assertHasUpdate(
         releasePullRequest!.updates,
@@ -205,10 +205,10 @@ describe('JavaYoshiMonoRepo', () => {
         .withArgs('versions.txt', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'versions.txt'));
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       assertHasUpdate(updates, 'versions.txt', VersionsManifest);
@@ -241,10 +241,10 @@ describe('JavaYoshiMonoRepo', () => {
         .withArgs('versions.txt', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'versions.txt'));
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       const {updater} = assertHasUpdate(updates, 'path1/pom.xml', JavaUpdate);
@@ -278,10 +278,10 @@ describe('JavaYoshiMonoRepo', () => {
         .withArgs('versions.txt', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'versions.txt'));
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       assertHasUpdate(updates, 'foo/bar.java', CompositeUpdater);
@@ -318,10 +318,10 @@ describe('JavaYoshiMonoRepo', () => {
           buildGitHubFileContent(fixturesPath, 'versions-released.txt')
         );
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertNoHasUpdate(updates, 'CHANGELOG.md');
       const {updater} = assertHasUpdate(updates, 'path1/pom.xml', JavaUpdate);
@@ -360,10 +360,10 @@ describe('JavaYoshiMonoRepo', () => {
         .withArgs('changelog.json', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'changelog.json'));
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       assertHasUpdate(updates, 'versions.txt', VersionsManifest);
@@ -420,10 +420,10 @@ describe('JavaYoshiMonoRepo', () => {
         .withArgs('changelog.json', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'changelog.json'));
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       assertHasUpdate(updates, 'versions.txt', VersionsManifest);
@@ -471,10 +471,10 @@ describe('JavaYoshiMonoRepo', () => {
         .withArgs('changelog.json', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'changelog.json'));
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       assertHasUpdate(updates, 'versions.txt', VersionsManifest);

--- a/test/strategies/java-yoshi.ts
+++ b/test/strategies/java-yoshi.ts
@@ -73,10 +73,10 @@ describe('JavaYoshi', () => {
         .withArgs('versions.txt', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'versions.txt'));
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
     it('returns release PR changes with semver patch bump', async () => {
@@ -99,10 +99,10 @@ describe('JavaYoshi', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
     it('returns a snapshot bump PR', async () => {
@@ -127,10 +127,10 @@ describe('JavaYoshi', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
     it('handles promotion to 1.0.0', async () => {
@@ -163,10 +163,10 @@ describe('JavaYoshi', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const releasePullRequest = await strategy.buildReleasePullRequest(
-        commits,
-        latestRelease
-      );
+      const releasePullRequest = await strategy.buildReleasePullRequest({
+        commits: commits,
+        latestRelease,
+      });
       expect(releasePullRequest!.version?.toString()).to.eql(expectedVersion);
       const update = assertHasUpdate(
         releasePullRequest!.updates,
@@ -202,7 +202,10 @@ describe('JavaYoshi', () => {
       };
       let failed = false;
       try {
-        await strategy.buildReleasePullRequest(COMMITS, latestRelease);
+        await strategy.buildReleasePullRequest({
+          commits: COMMITS,
+          latestRelease,
+        });
       } catch (e) {
         expect(e).instanceof(MissingRequiredFileError);
         failed = true;
@@ -226,10 +229,10 @@ describe('JavaYoshi', () => {
         .withArgs('versions.txt', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'versions.txt'));
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       assertHasUpdate(updates, 'versions.txt', VersionsManifest);
@@ -259,10 +262,10 @@ describe('JavaYoshi', () => {
         .withArgs('versions.txt', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'versions.txt'));
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       const {updater} = assertHasUpdate(updates, 'path1/pom.xml', JavaUpdate);
@@ -294,10 +297,10 @@ describe('JavaYoshi', () => {
         .withArgs('versions.txt', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'versions.txt'));
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       assertHasUpdate(updates, 'foo/bar.java', CompositeUpdater);
@@ -331,10 +334,10 @@ describe('JavaYoshi', () => {
           buildGitHubFileContent(fixturesPath, 'versions-released.txt')
         );
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertNoHasUpdate(updates, 'CHANGELOG.md');
       const {updater} = assertHasUpdate(updates, 'path1/pom.xml', JavaUpdate);

--- a/test/strategies/java.ts
+++ b/test/strategies/java.ts
@@ -63,12 +63,12 @@ describe('Java', () => {
         });
 
         const latestRelease = undefined;
-        const release = await strategy.buildReleasePullRequest(
-          COMMITS_WITH_SNAPSHOT,
+        const release = await strategy.buildReleasePullRequest({
+          commits: COMMITS_WITH_SNAPSHOT,
           latestRelease,
-          false,
-          DEFAULT_LABELS
-        );
+          draft: false,
+          labels: DEFAULT_LABELS,
+        });
 
         expect(release?.version?.toString()).to.eql('1.0.0');
         expect(release?.title.toString()).to.eql('chore(main): release 1.0.0');
@@ -89,12 +89,12 @@ describe('Java', () => {
           sha: 'abc123',
           notes: 'some notes',
         };
-        const release = await strategy.buildReleasePullRequest(
-          COMMITS_WITH_SNAPSHOT,
+        const release = await strategy.buildReleasePullRequest({
+          commits: COMMITS_WITH_SNAPSHOT,
           latestRelease,
-          false,
-          DEFAULT_LABELS
-        );
+          draft: false,
+          labels: DEFAULT_LABELS,
+        });
 
         expect(release?.version?.toString()).to.eql('2.3.4');
         expect(release?.title.toString()).to.eql('chore(main): release 2.3.4');
@@ -115,12 +115,12 @@ describe('Java', () => {
           sha: 'abc123',
           notes: 'some notes',
         };
-        const release = await strategy.buildReleasePullRequest(
-          COMMITS_NO_SNAPSHOT,
+        const release = await strategy.buildReleasePullRequest({
+          commits: COMMITS_NO_SNAPSHOT,
           latestRelease,
-          false,
-          DEFAULT_LABELS
-        );
+          draft: false,
+          labels: DEFAULT_LABELS,
+        });
 
         expect(release?.version?.toString()).to.eql('2.3.4-SNAPSHOT');
         expect(release?.title.toString()).to.eql(
@@ -144,12 +144,12 @@ describe('Java', () => {
           sha: 'abc123',
           notes: 'some notes',
         };
-        const release = await strategy.buildReleasePullRequest(
-          COMMITS_NO_SNAPSHOT,
+        const release = await strategy.buildReleasePullRequest({
+          commits: COMMITS_NO_SNAPSHOT,
           latestRelease,
-          false,
-          DEFAULT_LABELS
-        );
+          draft: false,
+          labels: DEFAULT_LABELS,
+        });
 
         expect(release?.version?.toString()).to.eql('2.3.4');
         expect(release?.title.toString()).to.eql('chore(main): release 2.3.4');
@@ -170,10 +170,10 @@ describe('Java', () => {
           sha: 'abc123',
           notes: 'some notes',
         };
-        const release = await strategy.buildReleasePullRequest(
-          COMMITS_NO_SNAPSHOT, // no snapshot in commits
-          latestRelease
-        );
+        const release = await strategy.buildReleasePullRequest({
+          commits: COMMITS_NO_SNAPSHOT, // no snapshot in commits
+          latestRelease,
+        });
 
         expect(release?.version?.toString()).to.eql('2.3.4');
         assertHasUpdate(release!.updates, 'CHANGELOG.md', Changelog);
@@ -190,15 +190,15 @@ describe('Java', () => {
           sha: 'abc123',
           notes: 'some notes',
         };
-        const release = await strategy.buildReleasePullRequest(
-          [
+        const release = await strategy.buildReleasePullRequest({
+          commits: [
             ...buildMockConventionalCommit(
               'chore(main): release other 2.3.4-SNAPSHOT'
             ),
             ...COMMITS_NO_SNAPSHOT,
           ],
-          latestRelease
-        );
+          latestRelease,
+        });
 
         expect(release?.version?.toString()).to.eql('2.3.4-SNAPSHOT');
         expect(release?.title.toString()).to.eql(
@@ -219,12 +219,12 @@ describe('Java', () => {
           sha: 'abc123',
           notes: 'some notes',
         };
-        const release = await strategy.buildReleasePullRequest(
-          COMMITS_NO_SNAPSHOT,
+        const release = await strategy.buildReleasePullRequest({
+          commits: COMMITS_NO_SNAPSHOT,
           latestRelease,
-          false,
-          ['custom:pending']
-        );
+          draft: false,
+          labels: ['custom:pending'],
+        });
 
         expect(release?.labels).to.eql(['bot', 'custom:snapshot']);
       });
@@ -240,11 +240,11 @@ describe('Java', () => {
           sha: 'abc123',
           notes: 'some notes',
         };
-        const release = await strategy.buildReleasePullRequest(
-          COMMITS_NO_SNAPSHOT,
+        const release = await strategy.buildReleasePullRequest({
+          commits: COMMITS_NO_SNAPSHOT,
           latestRelease,
-          true
-        );
+          draft: true,
+        });
 
         expect(release?.draft).to.eql(true);
       });
@@ -255,10 +255,10 @@ describe('Java', () => {
           github,
           extraFiles: ['foo/bar.java', 'pom.xml'],
         });
-        const release = await strategy.buildReleasePullRequest(
-          COMMITS_NO_SNAPSHOT,
-          undefined
-        );
+        const release = await strategy.buildReleasePullRequest({
+          commits: COMMITS_NO_SNAPSHOT,
+          latestRelease: undefined,
+        });
 
         const updates = release!.updates;
         assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
@@ -278,10 +278,10 @@ describe('Java', () => {
           sha: 'abc123',
           notes: 'some notes',
         };
-        const release = await strategy.buildReleasePullRequest(
-          COMMITS_NO_SNAPSHOT,
-          latestRelease
-        );
+        const release = await strategy.buildReleasePullRequest({
+          commits: COMMITS_NO_SNAPSHOT,
+          latestRelease,
+        });
 
         const updates = release!.updates;
         assertNoHasUpdate(updates, 'CHANGELOG.md');
@@ -316,12 +316,12 @@ describe('Java', () => {
           includeComponentInTag: true,
         });
 
-        const release = await strategy.buildReleasePullRequest(
-          COMMITS_WITH_SNAPSHOT,
-          undefined,
-          false,
-          DEFAULT_LABELS
-        );
+        const release = await strategy.buildReleasePullRequest({
+          commits: COMMITS_WITH_SNAPSHOT,
+          latestRelease: undefined,
+          draft: false,
+          labels: DEFAULT_LABELS,
+        });
 
         expect(release?.version?.toString()).to.eql('1.0.0');
         expect(release?.title.toString()).to.eql(
@@ -348,12 +348,12 @@ describe('Java', () => {
           sha: 'abc123',
           notes: 'some notes',
         };
-        const release = await strategy.buildReleasePullRequest(
-          COMMITS_WITH_SNAPSHOT,
+        const release = await strategy.buildReleasePullRequest({
+          commits: COMMITS_WITH_SNAPSHOT,
           latestRelease,
-          false,
-          DEFAULT_LABELS
-        );
+          draft: false,
+          labels: DEFAULT_LABELS,
+        });
 
         expect(release?.version?.toString()).to.eql('2.3.4');
         expect(release?.title.toString()).to.eql(
@@ -380,12 +380,12 @@ describe('Java', () => {
           sha: 'abc123',
           notes: 'some notes',
         };
-        const release = await strategy.buildReleasePullRequest(
-          COMMITS_NO_SNAPSHOT,
+        const release = await strategy.buildReleasePullRequest({
+          commits: COMMITS_NO_SNAPSHOT,
           latestRelease,
-          false,
-          DEFAULT_LABELS
-        );
+          draft: false,
+          labels: DEFAULT_LABELS,
+        });
 
         expect(release?.version?.toString()).to.eql('2.3.4-SNAPSHOT');
         expect(release?.title.toString()).to.eql(

--- a/test/strategies/krm-blueprint.ts
+++ b/test/strategies/krm-blueprint.ts
@@ -60,10 +60,10 @@ describe('KRMBlueprint', () => {
       });
       sandbox.stub(github, 'findFilesByExtensionAndRef').resolves([]);
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
+      const release = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
     it('builds a release pull request', async () => {
@@ -82,10 +82,10 @@ describe('KRMBlueprint', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const pullRequest = await strategy.buildReleasePullRequest(
+      const pullRequest = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(pullRequest!.version?.toString()).to.eql(expectedVersion);
     });
   });
@@ -98,10 +98,10 @@ describe('KRMBlueprint', () => {
       });
       sandbox.stub(github, 'findFilesByExtensionAndRef').resolves([]);
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
+      const release = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
     });
@@ -124,10 +124,10 @@ describe('KRMBlueprint', () => {
         targetBranch: 'main',
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
+      const release = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'project.yaml', KRMBlueprintVersion);
       assertNoHasUpdate(updates, 'no-attrib-bucket.yaml');

--- a/test/strategies/maven.ts
+++ b/test/strategies/maven.ts
@@ -61,10 +61,10 @@ describe('Maven', () => {
         .withArgs('pom.xml', 'main')
         .resolves(['pom.xml', 'submodule/pom.xml']);
 
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        undefined
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease: undefined,
+      });
 
       expect(release?.version?.toString()).to.eql('1.0.0');
 
@@ -99,10 +99,10 @@ describe('Maven', () => {
         notes: 'some notes',
       };
 
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
 
       expect(release?.version?.toString()).to.eql('2.3.4-SNAPSHOT');
 

--- a/test/strategies/node.ts
+++ b/test/strategies/node.ts
@@ -70,10 +70,10 @@ describe('Node', () => {
         packageName: 'google-cloud-automl',
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
+      const release = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
     it('builds a release pull request', async () => {
@@ -89,10 +89,10 @@ describe('Node', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const pullRequest = await strategy.buildReleasePullRequest(
+      const pullRequest = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(pullRequest!.version?.toString()).to.eql(expectedVersion);
     });
     it('detects a default component', async () => {
@@ -118,10 +118,10 @@ describe('Node', () => {
       getFileContentsStub
         .withArgs('package.json', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'package.json'));
-      const pullRequest = await strategy.buildReleasePullRequest(
+      const pullRequest = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(pullRequest!.version?.toString()).to.eql(expectedVersion);
     });
     it('detects a default packageName', async () => {
@@ -148,10 +148,10 @@ describe('Node', () => {
       getFileContentsStub
         .withArgs('package.json', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'package.json'));
-      const pullRequest = await strategy.buildReleasePullRequest(
+      const pullRequest = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(pullRequest!.version?.toString()).to.eql(expectedVersion);
     });
     it('handles missing package.json', async () => {
@@ -168,7 +168,7 @@ describe('Node', () => {
         notes: 'some notes',
       };
       assert.rejects(async () => {
-        await strategy.buildReleasePullRequest(commits, latestRelease);
+        await strategy.buildReleasePullRequest({commits, latestRelease});
       }, MissingRequiredFileError);
     });
     it('updates changelog.json if present', async () => {
@@ -200,10 +200,10 @@ describe('Node', () => {
         .withArgs('package.json', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'package.json'));
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       const update = assertHasUpdate(updates, 'changelog.json', ChangelogJson);
@@ -228,10 +228,10 @@ describe('Node', () => {
       });
       sandbox.stub(github, 'findFilesByFilenameAndRef').resolves([]);
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
+      const release = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       assertHasUpdate(updates, 'package-lock.json', PackageLockJson);

--- a/test/strategies/ocaml.ts
+++ b/test/strategies/ocaml.ts
@@ -65,10 +65,10 @@ describe('OCaml', () => {
       });
       sandbox.stub(github, 'findFilesByExtensionAndRef').resolves([]);
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
     it('returns release PR changes with semver patch bump', async () => {
@@ -84,10 +84,10 @@ describe('OCaml', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
   });
@@ -100,10 +100,10 @@ describe('OCaml', () => {
       });
       sandbox.stub(github, 'findFilesByExtensionAndRef').resolves([]);
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       expect(updates).lengthOf(2);
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
@@ -132,10 +132,10 @@ describe('OCaml', () => {
         files: ['esy.json', 'other.json', 'sample.opam', 'sample.opam.locked'],
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       expect(updates).lengthOf(5);
       assertHasUpdate(updates, 'esy.json', EsyJson);

--- a/test/strategies/php-yoshi.ts
+++ b/test/strategies/php-yoshi.ts
@@ -87,10 +87,10 @@ describe('PHPYoshi', () => {
         github,
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
+      const release = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
       snapshot(dateSafe(release!.body.toString()));
     });
@@ -105,10 +105,10 @@ describe('PHPYoshi', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const release = await strategy.buildReleasePullRequest(
+      const release = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
       snapshot(dateSafe(release!.body.toString()));
     });
@@ -123,16 +123,16 @@ describe('PHPYoshi', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const release = await strategy.buildReleasePullRequest(
-        [
+      const release = await strategy.buildReleasePullRequest({
+        commits: [
           {
             sha: 'def234',
             message: 'misc: some miscellaneous task',
             files: ['Client3/README.md'],
           },
         ],
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
       snapshot(dateSafe(release!.body.toString()));
     });
@@ -144,10 +144,10 @@ describe('PHPYoshi', () => {
         github,
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
+      const release = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       assertHasUpdate(updates, 'composer.json', RootComposerUpdatePackages);
@@ -158,10 +158,10 @@ describe('PHPYoshi', () => {
         github,
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
+      const release = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'Client1/VERSION', DefaultUpdater);
       assertHasUpdate(updates, 'Client2/VERSION', DefaultUpdater);
@@ -188,10 +188,10 @@ describe('PHPYoshi', () => {
       getFileStub
         .withArgs('.git/VERSION', 'main')
         .rejects(new FileNotFoundError('.git/VERSION'));
-      const release = await strategy.buildReleasePullRequest(
+      const release = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'Client1/VERSION', DefaultUpdater);
       assertHasUpdate(updates, 'Client2/VERSION', DefaultUpdater);

--- a/test/strategies/php.ts
+++ b/test/strategies/php.ts
@@ -57,10 +57,10 @@ describe('PHP', () => {
         component: 'google-cloud-automl',
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
     it('returns release PR changes with semver patch bump', async () => {
@@ -75,10 +75,10 @@ describe('PHP', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
   });
@@ -90,10 +90,10 @@ describe('PHP', () => {
         component: 'google-cloud-automl',
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       expect(updates).lengthOf(2);
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);

--- a/test/strategies/python.ts
+++ b/test/strategies/python.ts
@@ -72,10 +72,10 @@ describe('Python', () => {
         .resolves(buildGitHubFileContent(fixturesPath, 'setup.py'));
       sandbox.stub(github, 'findFilesByFilenameAndRef').resolves([]);
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
     it('returns release PR changes with semver patch bump', async () => {
@@ -94,10 +94,10 @@ describe('Python', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
   });
@@ -113,10 +113,10 @@ describe('Python', () => {
         .resolves(buildGitHubFileContent(fixturesPath, 'setup.py'));
       sandbox.stub(github, 'findFilesByFilenameAndRef').resolves([]);
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       assertHasUpdate(updates, 'setup.cfg', SetupCfg);
@@ -156,10 +156,10 @@ describe('Python', () => {
         );
       sandbox.stub(github, 'findFilesByFilenameAndRef').resolves([]);
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'pyproject.toml', PyProjectToml);
     });
@@ -177,10 +177,10 @@ describe('Python', () => {
         .stub(github, 'findFilesByFilenameAndRef')
         .resolves(['src/version.py']);
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'src/version.py', PythonFileWithVersion);
     });
@@ -214,10 +214,10 @@ describe('Python', () => {
         .withArgs('setup.py', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'setup.py'));
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       const update = assertHasUpdate(updates, 'changelog.json', ChangelogJson);

--- a/test/strategies/ruby-yoshi.ts
+++ b/test/strategies/ruby-yoshi.ts
@@ -59,10 +59,10 @@ describe('RubyYoshi', () => {
         component: 'google-cloud-automl',
       });
       const latestRelease = undefined;
-      const pullRequest = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const pullRequest = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(pullRequest!.version?.toString()).to.eql(expectedVersion);
     });
     it('returns release PR changes with semver patch bump', async () => {
@@ -77,10 +77,10 @@ describe('RubyYoshi', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const pullRequest = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const pullRequest = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(pullRequest!.version?.toString()).to.eql(expectedVersion);
       safeSnapshot(pullRequest!.body.toString());
     });
@@ -93,10 +93,10 @@ describe('RubyYoshi', () => {
         component: 'google-cloud-automl',
       });
       const latestRelease = undefined;
-      const pullRequest = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const pullRequest = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = pullRequest!.updates;
       expect(updates).lengthOf(2);
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
@@ -113,10 +113,10 @@ describe('RubyYoshi', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const pullRequest = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const pullRequest = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = pullRequest!.updates;
       expect(updates).lengthOf(2);
       const {updater} = assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
@@ -132,10 +132,10 @@ describe('RubyYoshi', () => {
         versionFile: 'lib/foo/version.rb',
       });
       const latestRelease = undefined;
-      const pullRequest = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const pullRequest = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = pullRequest!.updates;
       expect(updates).lengthOf(2);
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);

--- a/test/strategies/ruby.ts
+++ b/test/strategies/ruby.ts
@@ -59,10 +59,10 @@ describe('Ruby', () => {
         component: 'google-cloud-automl',
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
     it('returns release PR changes with semver patch bump', async () => {
@@ -77,10 +77,10 @@ describe('Ruby', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
   });
@@ -92,10 +92,10 @@ describe('Ruby', () => {
         component: 'google-cloud-automl',
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       expect(updates).lengthOf(3);
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
@@ -110,10 +110,10 @@ describe('Ruby', () => {
         versionFile: 'lib/foo/version.rb',
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       expect(updates).lengthOf(3);
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);

--- a/test/strategies/rust.ts
+++ b/test/strategies/rust.ts
@@ -60,10 +60,10 @@ describe('Rust', () => {
         component: 'google-cloud-automl',
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
 
@@ -79,10 +79,10 @@ describe('Rust', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
 
@@ -104,10 +104,10 @@ describe('Rust', () => {
       getFileContentsStub
         .withArgs('Cargo.toml', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'Cargo-crate1.toml'));
-      const pullRequest = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const pullRequest = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(pullRequest!.version?.toString()).to.eql(expectedVersion);
       snapshot(dateSafe(pullRequest!.body.toString()));
     });
@@ -141,10 +141,10 @@ describe('Rust Crate', () => {
         .withArgs('Cargo.lock', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'Cargo.lock'));
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       assertHasUpdate(updates, 'Cargo.toml', CargoToml);
@@ -182,10 +182,10 @@ describe('Rust Workspace', () => {
         .withArgs('Cargo.toml', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'Cargo-workspace.toml'));
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       assertHasUpdate(updates, 'Cargo.toml', CargoToml);
@@ -207,10 +207,10 @@ describe('Rust Workspace', () => {
         .withArgs('crates/crate2/Cargo.toml', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'Cargo-crate2.toml'));
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'crates/crate1/Cargo.toml', CargoToml);
       assertHasUpdate(updates, 'crates/crate2/Cargo.toml', CargoToml);

--- a/test/strategies/sfdx.ts
+++ b/test/strategies/sfdx.ts
@@ -61,10 +61,10 @@ describe('Sfdx', () => {
         packageName: 'google-cloud-automl',
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
+      const release = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
     it('builds a release pull request', async () => {
@@ -80,10 +80,10 @@ describe('Sfdx', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const pullRequest = await strategy.buildReleasePullRequest(
+      const pullRequest = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(pullRequest!.version?.toString()).to.eql(expectedVersion);
     });
     it('detects a default component', async () => {
@@ -109,10 +109,10 @@ describe('Sfdx', () => {
       getFileContentsStub
         .withArgs('sfdx-project.json', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'sfdx-project.json'));
-      const pullRequest = await strategy.buildReleasePullRequest(
+      const pullRequest = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(pullRequest!.version?.toString()).to.eql(expectedVersion);
     });
     it('detects a default packageName', async () => {
@@ -139,10 +139,10 @@ describe('Sfdx', () => {
       getFileContentsStub
         .withArgs('sfdx-project.json', 'main')
         .resolves(buildGitHubFileContent(fixturesPath, 'sfdx-project.json'));
-      const pullRequest = await strategy.buildReleasePullRequest(
+      const pullRequest = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       expect(pullRequest!.version?.toString()).to.eql(expectedVersion);
     });
     it('handles missing sfdx-project.json', async () => {
@@ -159,7 +159,7 @@ describe('Sfdx', () => {
         notes: 'some notes',
       };
       assert.rejects(async () => {
-        await strategy.buildReleasePullRequest(commits, latestRelease);
+        await strategy.buildReleasePullRequest({commits, latestRelease});
       }, MissingRequiredFileError);
     });
   });
@@ -173,10 +173,10 @@ describe('Sfdx', () => {
       });
       sandbox.stub(github, 'findFilesByFilenameAndRef').resolves([]);
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
+      const release = await strategy.buildReleasePullRequest({
         commits,
-        latestRelease
-      );
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       assertHasUpdate(updates, 'sfdx-project.json', SfdxProjectJson);

--- a/test/strategies/simple.ts
+++ b/test/strategies/simple.ts
@@ -61,7 +61,6 @@ describe('Simple', () => {
       const release = await strategy.buildReleasePullRequest({
         commits: COMMITS,
         latestRelease,
-        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
       });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
@@ -80,7 +79,6 @@ describe('Simple', () => {
       const release = await strategy.buildReleasePullRequest({
         commits: COMMITS,
         latestRelease,
-        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
       });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
@@ -96,7 +94,6 @@ describe('Simple', () => {
       const release = await strategy.buildReleasePullRequest({
         commits: COMMITS,
         latestRelease,
-        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
       });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
@@ -114,7 +111,6 @@ describe('Simple', () => {
       const release = await strategy.buildReleasePullRequest({
         commits: COMMITS,
         latestRelease,
-        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
       });
       const updates = release!.updates;
       assertHasUpdate(updates, 'packages/CHANGELOG.md', Changelog);

--- a/test/strategies/simple.ts
+++ b/test/strategies/simple.ts
@@ -23,7 +23,6 @@ import {TagName} from '../../src/util/tag-name';
 import {Version} from '../../src/version';
 import {Changelog} from '../../src/updaters/changelog';
 import {DefaultUpdater} from '../../src/updaters/default';
-import {DEFAULT_RELEASE_PLEASE_MANIFEST} from '../../src/manifest';
 
 const sandbox = sinon.createSandbox();
 

--- a/test/strategies/simple.ts
+++ b/test/strategies/simple.ts
@@ -23,6 +23,7 @@ import {TagName} from '../../src/util/tag-name';
 import {Version} from '../../src/version';
 import {Changelog} from '../../src/updaters/changelog';
 import {DefaultUpdater} from '../../src/updaters/default';
+import {DEFAULT_RELEASE_PLEASE_MANIFEST} from '../../src/manifest';
 
 const sandbox = sinon.createSandbox();
 
@@ -57,10 +58,11 @@ describe('Simple', () => {
         component: 'google-cloud-automl',
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
     it('returns release PR changes with semver patch bump', async () => {
@@ -75,10 +77,11 @@ describe('Simple', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
   });
@@ -90,10 +93,11 @@ describe('Simple', () => {
         component: 'google-cloud-automl',
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       assertHasUpdate(updates, 'version.txt', DefaultUpdater);
@@ -107,10 +111,11 @@ describe('Simple', () => {
         path: 'packages',
       });
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+        manifestPath: DEFAULT_RELEASE_PLEASE_MANIFEST,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'packages/CHANGELOG.md', Changelog);
       assertHasUpdate(updates, 'packages/some-path/VERSION', DefaultUpdater);

--- a/test/strategies/terraform-module.ts
+++ b/test/strategies/terraform-module.ts
@@ -58,10 +58,10 @@ describe('TerraformModule', () => {
       });
       sandbox.stub(github, 'findFilesByFilenameAndRef').resolves([]);
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
     it('returns release PR changes with semver patch bump', async () => {
@@ -77,10 +77,10 @@ describe('TerraformModule', () => {
         sha: 'abc123',
         notes: 'some notes',
       };
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       expect(release!.version?.toString()).to.eql(expectedVersion);
     });
   });
@@ -93,10 +93,10 @@ describe('TerraformModule', () => {
       });
       sandbox.stub(github, 'findFilesByFilenameAndRef').resolves([]);
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
     });
@@ -121,10 +121,10 @@ describe('TerraformModule', () => {
         .withArgs('versions.tf.tmpl', 'main', '.')
         .resolves(['path1/versions.tf.tmpl', 'path2/versions.tf.tmpl']);
       const latestRelease = undefined;
-      const release = await strategy.buildReleasePullRequest(
-        COMMITS,
-        latestRelease
-      );
+      const release = await strategy.buildReleasePullRequest({
+        commits: COMMITS,
+        latestRelease,
+      });
       const updates = release!.updates;
       assertHasUpdate(updates, 'path1/readme.md', ReadMe);
       assertHasUpdate(updates, 'path2/readme.md', ReadMe);


### PR DESCRIPTION
To determine if the user edited the version from the PR title `release-please` does the following:
1. before building a release PR object, check if a PR already without a label exists for the release branch
2. if the PR has a label `autorelease: custom version`, use the version from the title and stop here
3. fetch the manifest from the release branch, get the version number for the relevant component
4. compare the version number with the PR title version number
5. if they don't match, we assume the end user edited the PR title version and use it
6. add a label `autorelease: custom version` to the PR
7. write a comment to the PR "The release version will not be automatically updated as it has been manually edited. If you want to use the calculated version remove the label `autorelease: custom version`"

For my tests I am using a github action like this one:

```yaml
name: Handle release PR title edits
on:
  pull_request:
    types:
      - edited
      - unlabeled

jobs:
  update_pr_content:
    name: Update pull request content
    if: |
      (github.event.type == 'edited' && github.event.changes.title.from != github.event.pull_request.title) ||
      (github.event.type == 'unlabeled' && github.event.label.name == 'autorelease: custom version') &&
      github.event.pull_request.state == 'open' &&
      github.event.sender.login != 'stainless-bot' &&
      github.repository == 'stainless-sdks/sink-java-public'
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3
      - uses: stainless-api/trigger-release-please@v1
        with:
          repo: ${{ github.event.repository.full_name }}
          stainless-api-key: ${{ secrets.STAINLESS_API_KEY }}
```



You can find an example of a release with a custom label [here](https://github.com/stainless-sdks/sink-java-public/releases/tag/v1.2.3-beta.1), and the release pull request [here](https://github.com/stainless-sdks/sink-java-public/pull/93).