### PR TITLE
Fetch release-please manifest and config files from changes-branch

### DIFF
--- a/__snapshots__/base.js
+++ b/__snapshots__/base.js
@@ -41,7 +41,7 @@ exports['Strategy buildReleasePullRequest should pass changelogHost to default b
 ---
 
 
-## 1.0.0 (1983-10-10)
+## 0.0.1 (1983-10-10)
 
 
 ### Bug Fixes

--- a/__snapshots__/dotnet-yoshi.js
+++ b/__snapshots__/dotnet-yoshi.js
@@ -3,7 +3,7 @@ exports['DotnetYoshi buildReleasePullRequest returns release PR changes with def
 ---
 
 
-## Version 1.0.0, released 1983-10-10
+## Version 0.0.1, released 1983-10-10
 
 
 ### Bug fixes
@@ -39,7 +39,7 @@ _More technical details can be found at [stainless-api/release-please](https://g
 `
 
 exports['DotnetYoshi buildUpdates builds common files 1'] = `
-## Version 1.0.0, released 1983-10-10
+## Version 0.0.1, released 1983-10-10
 
 
 ### Bug fixes

--- a/__snapshots__/go-yoshi.js
+++ b/__snapshots__/go-yoshi.js
@@ -3,7 +3,7 @@ exports['GoYoshi buildReleasePullRequest combines google-api-go-client autogener
 ---
 
 
-## 0.1.0 (1983-10-10)
+## 0.0.1 (1983-10-10)
 
 
 ### Features
@@ -22,7 +22,7 @@ exports['GoYoshi buildReleasePullRequest filters out submodule commits 1'] = `
 ---
 
 
-## 0.1.0 (1983-10-10)
+## 0.0.1 (1983-10-10)
 
 
 ### Bug Fixes
@@ -41,7 +41,7 @@ exports['GoYoshi buildReleasePullRequest filters out touched files not matching 
 ---
 
 
-## 0.1.0 (1983-10-10)
+## 0.0.1 (1983-10-10)
 
 
 ### Bug Fixes

--- a/__snapshots__/java-yoshi-mono-repo.js
+++ b/__snapshots__/java-yoshi-mono-repo.js
@@ -22,7 +22,7 @@ exports['JavaYoshiMonoRepo buildUpdates omits non-breaking chores from changelog
           "breakingChangeNote": "update a very important dep"
         }
       ],
-      "version": "0.1.0",
+      "version": "0.0.1",
       "language": "JAVA",
       "artifactName": "cloud.google.com:foo",
       "id": "abc-123-efd-qwerty",
@@ -46,7 +46,7 @@ exports['JavaYoshiMonoRepo buildUpdates updates changelog.json 1'] = `
           "scope": "deps"
         }
       ],
-      "version": "0.1.0",
+      "version": "0.0.1",
       "language": "JAVA",
       "artifactName": "cloud.google.com:foo",
       "id": "abc-123-efd-qwerty",

--- a/__snapshots__/node.js
+++ b/__snapshots__/node.js
@@ -25,7 +25,7 @@ exports['Node buildReleasePullRequest updates changelog.json if present 1'] = `
           "scope": "deps"
         }
       ],
-      "version": "1.0.0",
+      "version": "0.0.1",
       "language": "JAVASCRIPT",
       "artifactName": "node-test-repo",
       "id": "abc-123-efd-qwerty",

--- a/__snapshots__/php-yoshi.js
+++ b/__snapshots__/php-yoshi.js
@@ -763,7 +763,7 @@ exports['PHPYoshi buildReleasePullRequest returns release PR changes with defaul
 ---
 
 
-## 1.0.0
+## 0.0.1
 
 <details><summary>google/client1 1.2.4</summary>
 

--- a/__snapshots__/python.js
+++ b/__snapshots__/python.js
@@ -25,7 +25,7 @@ exports['Python buildUpdates updates changelog.json if present 1'] = `
           "scope": "deps"
         }
       ],
-      "version": "0.1.0",
+      "version": "0.0.1",
       "language": "PYTHON",
       "artifactName": "google-cloud-automl",
       "id": "abc-123-efd-qwerty",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,6 @@
   "main": "./build/src/index.js",
   "bin": "./build/src/bin/release-please.js",
   "scripts": {
-    "test:node14": "cross-env ENVIRONMENT=test LC_ALL=en c8 mocha --require build/test/_fetch-polyfill.js --recursive --timeout=5000 build/test",
-    "test:node16": "npm run test:node14",
     "test:node18": "cross-env ENVIRONMENT=test LC_ALL=en c8 mocha --node-option no-experimental-fetch --require build/test/_fetch-polyfill.js --recursive --timeout=5000 build/test",
     "test:node20": "npm run test:node18",
     "test": "npm run test:node18",

--- a/src/changelog-notes/default.ts
+++ b/src/changelog-notes/default.ts
@@ -103,9 +103,10 @@ export class DefaultChangelogNotes implements ChangelogNotes {
       };
     });
 
-    return conventionalChangelogWriter
+    const result = conventionalChangelogWriter
       .parseArray(changelogCommits, context, preset.writerOpts)
       .trim();
+    return result;
   }
 }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -306,6 +306,7 @@ export class GitHub {
           doNotRetry: [
             '403', // Used by GitHub when throttling
             '429', // Too Many Request
+            '404', // Not Found
           ],
         },
         throttle: {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -411,12 +411,13 @@ export class Manifest {
     path?: string,
     releaseAs?: string
   ): Promise<Manifest> {
+    const changesBranch = manifestOptionOverrides.changesBranch ?? targetBranch;
     const [
       {config: repositoryConfig, options: manifestOptions},
       releasedVersions,
     ] = await Promise.all([
-      parseConfig(github, configFile, targetBranch, path, releaseAs),
-      parseReleasedVersions(github, manifestFile, targetBranch),
+      parseConfig(github, configFile, changesBranch, path, releaseAs),
+      parseReleasedVersions(github, manifestFile, changesBranch),
     ]);
     return new Manifest(
       github,
@@ -742,8 +743,6 @@ export class Manifest {
       const existingPR =
         openPullRequests.find(pr => pr.headBranchName === branchName) ||
         snoozedPullRequests.find(pr => pr.headBranchName === branchName);
-
-      this.logger.debug({existingPR});
 
       const releasePullRequest = await strategy.buildReleasePullRequest({
         commits: pathCommits,

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -434,6 +434,7 @@ If you instead want to use the version number \`${newVersion}\` generated from c
       latestRelease,
       commits
     );
+
     if (this.changelogEmpty(releaseNotesBody)) {
       this.logger.info(
         `No user facing commits found since ${
@@ -751,7 +752,7 @@ If you instead want to use the version number \`${newVersion}\` generated from c
       return Version.parse(this.initialVersion);
     }
 
-    return Version.parse('1.0.0');
+    return Version.parse('0.0.1');
   }
 
   /**

--- a/src/strategies/go-yoshi.ts
+++ b/src/strategies/go-yoshi.ts
@@ -197,7 +197,7 @@ export class GoYoshi extends BaseStrategy {
   }
 
   protected initialReleaseVersion(): Version {
-    return Version.parse('0.1.0');
+    return Version.parse('0.0.1');
   }
 }
 

--- a/src/strategies/go-yoshi.ts
+++ b/src/strategies/go-yoshi.ts
@@ -195,10 +195,6 @@ export class GoYoshi extends BaseStrategy {
     );
     return releaseNotes.replace(/, closes /g, ', refs ');
   }
-
-  protected initialReleaseVersion(): Version {
-    return Version.parse('0.0.1');
-  }
 }
 
 function commitMatchesScope(commitScope: string, scope: string): boolean {

--- a/src/strategies/java-yoshi-mono-repo.ts
+++ b/src/strategies/java-yoshi-mono-repo.ts
@@ -315,7 +315,7 @@ export class JavaYoshiMonoRepo extends Java {
   }
 
   protected initialReleaseVersion(): Version {
-    return Version.parse('0.1.0');
+    return Version.parse('0.0.1');
   }
 }
 

--- a/src/strategies/java-yoshi-mono-repo.ts
+++ b/src/strategies/java-yoshi-mono-repo.ts
@@ -313,10 +313,6 @@ export class JavaYoshiMonoRepo extends Java {
     }
     return versionsMap;
   }
-
-  protected initialReleaseVersion(): Version {
-    return Version.parse('0.0.1');
-  }
 }
 
 const VERSIONED_ARTIFACT_REGEX = /^.*-(v\d+[^-]*)$/;

--- a/src/strategies/java-yoshi.ts
+++ b/src/strategies/java-yoshi.ts
@@ -221,7 +221,7 @@ export class JavaYoshi extends Java {
   }
 
   protected initialReleaseVersion(): Version {
-    return Version.parse('0.1.0');
+    return Version.parse('0.0.1');
   }
 }
 

--- a/src/strategies/java-yoshi.ts
+++ b/src/strategies/java-yoshi.ts
@@ -219,10 +219,6 @@ export class JavaYoshi extends Java {
     }
     return versionsMap;
   }
-
-  protected initialReleaseVersion(): Version {
-    return Version.parse('0.0.1');
-  }
 }
 
 const VERSIONED_ARTIFACT_REGEX = /^.*-(v\d+[^-]*)$/;

--- a/src/strategies/krm-blueprint.ts
+++ b/src/strategies/krm-blueprint.ts
@@ -20,7 +20,7 @@ import {Changelog} from '../updaters/changelog';
 import {KRMBlueprintVersion} from '../updaters/krm/krm-blueprint-version';
 import {BaseStrategy, BuildUpdatesOptions} from './base';
 import {Update} from '../update';
-import {VersionsMap, Version} from '../version';
+import {VersionsMap} from '../version';
 
 const KRMBlueprintAttribAnnotation = 'cnrm.cloud.google.com/blueprint';
 const hasKRMBlueprintAttrib = (content: string) =>

--- a/src/strategies/krm-blueprint.ts
+++ b/src/strategies/krm-blueprint.ts
@@ -73,8 +73,4 @@ export class KRMBlueprint extends BaseStrategy {
     }
     return updates;
   }
-
-  protected initialReleaseVersion(): Version {
-    return Version.parse('0.0.1');
-  }
 }

--- a/src/strategies/krm-blueprint.ts
+++ b/src/strategies/krm-blueprint.ts
@@ -75,6 +75,6 @@ export class KRMBlueprint extends BaseStrategy {
   }
 
   protected initialReleaseVersion(): Version {
-    return Version.parse('0.1.0');
+    return Version.parse('0.0.1');
   }
 }

--- a/src/strategies/python.ts
+++ b/src/strategies/python.ts
@@ -195,8 +195,4 @@ export class Python extends BaseStrategy {
       }
     }
   }
-
-  protected initialReleaseVersion(): Version {
-    return Version.parse('0.0.1');
-  }
 }

--- a/src/strategies/python.ts
+++ b/src/strategies/python.ts
@@ -197,6 +197,6 @@ export class Python extends BaseStrategy {
   }
 
   protected initialReleaseVersion(): Version {
-    return Version.parse('0.1.0');
+    return Version.parse('0.0.1');
   }
 }

--- a/src/strategies/python.ts
+++ b/src/strategies/python.ts
@@ -16,7 +16,6 @@ import {BaseStrategy, BuildUpdatesOptions, BaseStrategyOptions} from './base';
 import {Update} from '../update';
 import {Changelog} from '../updaters/changelog';
 import {ChangelogJson} from '../updaters/changelog-json';
-import {Version} from '../version';
 import {SetupCfg} from '../updaters/python/setup-cfg';
 import {SetupPy} from '../updaters/python/setup-py';
 import {

--- a/src/strategies/rust.ts
+++ b/src/strategies/rust.ts
@@ -21,7 +21,7 @@ import {CargoToml} from '../updaters/rust/cargo-toml';
 import {CargoLock} from '../updaters/rust/cargo-lock';
 import {CargoManifest, parseCargoManifest} from '../updaters/rust/common';
 import {BaseStrategy, BuildUpdatesOptions} from './base';
-import {VersionsMap, Version} from '../version';
+import {VersionsMap} from '../version';
 import {Update} from '../update';
 
 export class Rust extends BaseStrategy {

--- a/src/strategies/rust.ts
+++ b/src/strategies/rust.ts
@@ -129,10 +129,6 @@ export class Rust extends BaseStrategy {
     return updates;
   }
 
-  protected initialReleaseVersion(): Version {
-    return Version.parse('0.0.1');
-  }
-
   async getDefaultPackageName(): Promise<string | undefined> {
     const packageManifest = await this.getPackageManifest();
     if (packageManifest) {

--- a/src/strategies/rust.ts
+++ b/src/strategies/rust.ts
@@ -130,7 +130,7 @@ export class Rust extends BaseStrategy {
   }
 
   protected initialReleaseVersion(): Version {
-    return Version.parse('0.1.0');
+    return Version.parse('0.0.1');
   }
 
   async getDefaultPackageName(): Promise<string | undefined> {

--- a/src/strategies/terraform-module.ts
+++ b/src/strategies/terraform-module.ts
@@ -20,7 +20,6 @@ import {ModuleVersion} from '../updaters/terraform/module-version';
 import {MetadataVersion} from '../updaters/terraform/metadata-version';
 import {BaseStrategy, BuildUpdatesOptions} from './base';
 import {Update} from '../update';
-import {Version} from '../version';
 
 export class TerraformModule extends BaseStrategy {
   protected async buildUpdates(

--- a/src/strategies/terraform-module.ts
+++ b/src/strategies/terraform-module.ts
@@ -110,6 +110,6 @@ export class TerraformModule extends BaseStrategy {
   }
 
   protected initialReleaseVersion(): Version {
-    return Version.parse('0.1.0');
+    return Version.parse('0.0.1');
   }
 }

--- a/src/strategies/terraform-module.ts
+++ b/src/strategies/terraform-module.ts
@@ -108,8 +108,4 @@ export class TerraformModule extends BaseStrategy {
     });
     return updates;
   }
-
-  protected initialReleaseVersion(): Version {
-    return Version.parse('0.0.1');
-  }
 }

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -228,11 +228,11 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(
           buildGitHubFileContent(fixturesPath, 'manifest/config/config.json')
         )
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
@@ -244,7 +244,7 @@ describe('Manifest', () => {
         github.repository.defaultBranch,
         undefined,
         undefined,
-        undefined,
+        {changesBranch: 'next'},
         'packages/gcf-utils'
       );
       expect(Object.keys(manifest.repositoryConfig)).lengthOf(1);
@@ -259,11 +259,11 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(
           buildGitHubFileContent(fixturesPath, 'manifest/config/config.json')
         )
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
@@ -275,7 +275,7 @@ describe('Manifest', () => {
         github.repository.defaultBranch,
         undefined,
         undefined,
-        undefined,
+        {changesBranch: 'next'},
         'packages/gcf-utils',
         '12.34.56'
       );
@@ -291,14 +291,14 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
             'manifest/config/root-release-type.json'
           )
         )
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
@@ -307,7 +307,10 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
-        github.repository.defaultBranch
+        github.repository.defaultBranch,
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
       );
       expect(manifest.repositoryConfig['.'].releaseType).to.eql('java-yoshi');
       expect(manifest.repositoryConfig['node-package'].releaseType).to.eql(
@@ -320,14 +323,14 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
             'manifest/config/group-pr-title-pattern.json'
           )
         )
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
@@ -336,7 +339,10 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
-        github.repository.defaultBranch
+        github.repository.defaultBranch,
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
       );
       expect(manifest['groupPullRequestTitlePattern']).to.eql(
         'chore${scope}: release${component} v${version}'
@@ -352,14 +358,14 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
             'manifest/config/tag-separator.json'
           )
         )
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
@@ -368,7 +374,10 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
-        github.repository.defaultBranch
+        github.repository.defaultBranch,
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
       );
       expect(manifest.repositoryConfig['.'].tagSeparator).to.eql('-');
       expect(
@@ -382,14 +391,14 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
             'manifest/config/extra-files.json'
           )
         )
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
@@ -398,7 +407,10 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
-        github.repository.defaultBranch
+        github.repository.defaultBranch,
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
       );
       expect(manifest.repositoryConfig['.'].extraFiles).to.eql([
         'default.txt',
@@ -426,14 +438,14 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
             'manifest/config/include-component-in-tag.json'
           )
         )
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
@@ -442,7 +454,10 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
-        github.repository.defaultBranch
+        github.repository.defaultBranch,
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
       );
       expect(manifest.repositoryConfig['.'].includeComponentInTag).to.be.false;
       expect(
@@ -457,14 +472,14 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
             'manifest/config/include-v-in-tag.json'
           )
         )
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
@@ -473,7 +488,10 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
-        github.repository.defaultBranch
+        github.repository.defaultBranch,
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
       );
       expect(manifest.repositoryConfig['.'].includeVInTag).to.be.false;
       expect(
@@ -487,11 +505,11 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(
           buildGitHubFileContent(fixturesPath, 'manifest/config/labels.json')
         )
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
@@ -500,7 +518,10 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
-        github.repository.defaultBranch
+        github.repository.defaultBranch,
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
       );
       expect(manifest['labels']).to.deep.equal(['custom: pending']);
       expect(manifest['releaseLabels']).to.deep.equal(['custom: tagged']);
@@ -514,14 +535,14 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
             'manifest/config/extra-labels.json'
           )
         )
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
@@ -530,7 +551,10 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
-        github.repository.defaultBranch
+        github.repository.defaultBranch,
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
       );
       expect(manifest.repositoryConfig['.'].extraLabels).to.deep.equal([
         'lang: java',
@@ -545,14 +569,14 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
             'manifest/config/exclude-paths.json'
           )
         )
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
@@ -561,7 +585,10 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
-        github.repository.defaultBranch
+        github.repository.defaultBranch,
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
       );
       expect(manifest.repositoryConfig['.'].excludePaths).to.deep.equal([
         'path-root-ignore',
@@ -576,11 +603,11 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(
           buildGitHubFileContent(fixturesPath, 'manifest/config/plugins.json')
         )
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
@@ -589,7 +616,10 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
-        github.repository.defaultBranch
+        github.repository.defaultBranch,
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
       );
       expect(manifest.plugins).lengthOf(2);
       expect(manifest.plugins[0]).instanceOf(NodeWorkspace);
@@ -601,14 +631,14 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
             'manifest/config/complex-plugins.json'
           )
         )
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
@@ -617,7 +647,10 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
-        github.repository.defaultBranch
+        github.repository.defaultBranch,
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
       );
       expect(manifest.plugins).lengthOf(1);
       expect(manifest.plugins[0]).instanceOf(LinkedVersions);
@@ -631,14 +664,14 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
             'manifest/config/maven-workspace-plugins.json'
           )
         )
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
@@ -647,7 +680,10 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
-        github.repository.defaultBranch
+        github.repository.defaultBranch,
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
       );
       expect(manifest.plugins).lengthOf(1);
       expect(manifest.plugins[0]).instanceOf(MavenWorkspace);
@@ -660,14 +696,14 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
             'manifest/config/search-depth.json'
           )
         )
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
@@ -676,7 +712,10 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
-        github.repository.defaultBranch
+        github.repository.defaultBranch,
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
       );
       expect(manifest.releaseSearchDepth).to.eql(10);
       expect(manifest.commitSearchDepth).to.eql(50);
@@ -688,14 +727,14 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
             'manifest/config/changelog-host.json'
           )
         )
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
@@ -704,7 +743,10 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
-        github.repository.defaultBranch
+        github.repository.defaultBranch,
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
       );
       expect(manifest.repositoryConfig['.'].changelogHost).to.eql(
         'https://example.com'
@@ -720,14 +762,14 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
             'manifest/config/changelog-type.json'
           )
         )
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
@@ -736,7 +778,10 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
-        github.repository.defaultBranch
+        github.repository.defaultBranch,
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
       );
       expect(manifest.repositoryConfig['.'].changelogType).to.eql('github');
       expect(
@@ -750,14 +795,14 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
             'manifest/config/changelog-path.json'
           )
         )
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
@@ -766,7 +811,10 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
-        github.repository.defaultBranch
+        github.repository.defaultBranch,
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
       );
       expect(manifest.repositoryConfig['.'].changelogPath).to.eql(
         'docs/foo.md'
@@ -782,14 +830,14 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
             'manifest/config/versioning.json'
           )
         )
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
@@ -798,7 +846,10 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
-        github.repository.defaultBranch
+        github.repository.defaultBranch,
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
       );
       expect(manifest.repositoryConfig['.'].versioning).to.eql(
         'always-bump-patch'
@@ -814,9 +865,9 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .rejects(new FileNotFoundError('.release-please-config.json'))
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
@@ -824,7 +875,13 @@ describe('Manifest', () => {
           )
         );
       await assert.rejects(async () => {
-        await Manifest.fromManifest(github, github.repository.defaultBranch);
+        await Manifest.fromManifest(
+          github,
+          github.repository.defaultBranch,
+          undefined,
+          undefined,
+          {changesBranch: 'next'}
+        );
       }, ConfigurationError);
     });
 
@@ -834,14 +891,20 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(
           buildGitHubFileContent(fixturesPath, 'manifest/config/config.json')
         )
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .rejects(new FileNotFoundError('.release-please-manifest.json'));
       await assert.rejects(async () => {
-        await Manifest.fromManifest(github, github.repository.defaultBranch);
+        await Manifest.fromManifest(
+          github,
+          github.repository.defaultBranch,
+          undefined,
+          undefined,
+          {changesBranch: 'next'}
+        );
       }, ConfigurationError);
     });
 
@@ -851,9 +914,9 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(buildGitHubFileRaw('{"malformed json"'))
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileContent(
             fixturesPath,
@@ -862,7 +925,13 @@ describe('Manifest', () => {
         );
       await assert.rejects(
         async () => {
-          await Manifest.fromManifest(github, github.repository.defaultBranch);
+          await Manifest.fromManifest(
+            github,
+            github.repository.defaultBranch,
+            undefined,
+            undefined,
+            {changesBranch: 'next'}
+          );
         },
         e => {
           console.log(e);
@@ -877,15 +946,21 @@ describe('Manifest', () => {
         'getFileContentsOnBranch'
       );
       getFileContentsStub
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(
           buildGitHubFileContent(fixturesPath, 'manifest/config/config.json')
         )
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(buildGitHubFileRaw('{"malformed json"'));
       await assert.rejects(
         async () => {
-          await Manifest.fromManifest(github, github.repository.defaultBranch);
+          await Manifest.fromManifest(
+            github,
+            github.repository.defaultBranch,
+            undefined,
+            undefined,
+            {changesBranch: 'next'}
+          );
         },
         e => {
           console.log(e);
@@ -1569,11 +1644,11 @@ describe('Manifest', () => {
           'getFileContentsOnBranch'
         );
         getFileContentsStub
-          .withArgs('release-please-config.json', 'main')
+          .withArgs('release-please-config.json', 'next')
           .resolves(
             buildGitHubFileContent(fixturesPath, 'manifest/config/simple.json')
           )
-          .withArgs('non/default/path/manifest.json', 'main')
+          .withArgs('non/default/path/manifest.json', 'next')
           .resolves(
             buildGitHubFileContent(
               fixturesPath,
@@ -1584,7 +1659,8 @@ describe('Manifest', () => {
           github,
           'main',
           undefined,
-          'non/default/path/manifest.json'
+          'non/default/path/manifest.json',
+          {changesBranch: 'next'}
         );
         const pullRequests = await manifest.buildPullRequests([], []);
         expect(pullRequests).lengthOf(1);
@@ -2020,11 +2096,17 @@ describe('Manifest', () => {
       };
       sandbox
         .stub(github, 'getFileContentsOnBranch')
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(buildGitHubFileRaw(JSON.stringify(config)))
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(buildGitHubFileRaw(JSON.stringify(versions)));
-      const manifest = await Manifest.fromManifest(github, 'main');
+      const manifest = await Manifest.fromManifest(
+        github,
+        'main',
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
+      );
       const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(2);
       expect(pullRequests[0].version?.toString()).to.eql('1.0.1');
@@ -2113,11 +2195,17 @@ describe('Manifest', () => {
       };
       sandbox
         .stub(github, 'getFileContentsOnBranch')
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(buildGitHubFileRaw(JSON.stringify(config)))
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(buildGitHubFileRaw(JSON.stringify(versions)));
-      const manifest = await Manifest.fromManifest(github, 'main');
+      const manifest = await Manifest.fromManifest(
+        github,
+        'main',
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
+      );
       const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(2);
       expect(pullRequests[0].version?.toString()).to.eql('3.3.3');
@@ -2848,11 +2936,17 @@ version = "3.0.0"
       };
       sandbox
         .stub(github, 'getFileContentsOnBranch')
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(buildGitHubFileRaw(JSON.stringify(config)))
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(buildGitHubFileRaw(JSON.stringify(versions)));
-      const manifest = await Manifest.fromManifest(github, 'main');
+      const manifest = await Manifest.fromManifest(
+        github,
+        'main',
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
+      );
       const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(1);
       expect(pullRequests[0].version?.toString()).to.eql('0.0.1');
@@ -2941,11 +3035,17 @@ version = "3.0.0"
       };
       sandbox
         .stub(github, 'getFileContentsOnBranch')
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(buildGitHubFileRaw(JSON.stringify(config)))
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(buildGitHubFileRaw(JSON.stringify(versions)));
-      const manifest = await Manifest.fromManifest(github, 'main');
+      const manifest = await Manifest.fromManifest(
+        github,
+        'main',
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
+      );
       const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(1);
       expect(pullRequests[0].version?.toString()).to.eql('0.0.1');
@@ -3195,11 +3295,17 @@ version = "3.0.0"
       };
       sandbox
         .stub(github, 'getFileContentsOnBranch')
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(buildGitHubFileRaw(JSON.stringify(config)))
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(buildGitHubFileRaw(JSON.stringify(versions)));
-      const manifest = await Manifest.fromManifest(github, 'main');
+      const manifest = await Manifest.fromManifest(
+        github,
+        'main',
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
+      );
       const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(1);
       expect(pullRequests[0].body.releaseData).lengthOf(1);

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -195,6 +195,33 @@ describe('Manifest', () => {
       expect(Object.keys(manifest.repositoryConfig)).lengthOf(8);
       expect(Object.keys(manifest.releasedVersions)).lengthOf(8);
     });
+    it('should fetch config and manifest from changes-branch when specified', async () => {
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('release-please-config.json', 'next')
+        .resolves(
+          buildGitHubFileContent(fixturesPath, 'manifest/config/config.json')
+        )
+        .withArgs('.release-please-manifest.json', 'next')
+        .resolves(
+          buildGitHubFileContent(
+            fixturesPath,
+            'manifest/versions/versions.json'
+          )
+        );
+      const manifest = await Manifest.fromManifest(
+        github,
+        github.repository.defaultBranch,
+        undefined,
+        undefined,
+        {changesBranch: 'next'}
+      );
+      expect(Object.keys(manifest.repositoryConfig)).lengthOf(8);
+      expect(Object.keys(manifest.releasedVersions)).lengthOf(8);
+    });
     it('should limit manifest loading to the given path', async () => {
       const getFileContentsStub = sandbox.stub(
         github,
@@ -2235,9 +2262,9 @@ describe('Manifest', () => {
 
       const getFileContentsOnBranchStub = sandbox
         .stub(github, 'getFileContentsOnBranch')
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(buildGitHubFileRaw(JSON.stringify(config)))
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileRaw(
             JSON.stringify({
@@ -2473,9 +2500,9 @@ version = "3.0.0"
 
       const getFileContentsOnBranchStub = sandbox
         .stub(github, 'getFileContentsOnBranch')
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(buildGitHubFileRaw(JSON.stringify(config)))
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileRaw(
             JSON.stringify({
@@ -2594,9 +2621,9 @@ version = "3.0.0"
 
       const getFileContentsOnBranchStub = sandbox
         .stub(github, 'getFileContentsOnBranch')
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(buildGitHubFileRaw(JSON.stringify(config)))
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileRaw(
             JSON.stringify({
@@ -2725,9 +2752,9 @@ version = "3.0.0"
 
       const getFileContentsOnBranchStub = sandbox
         .stub(github, 'getFileContentsOnBranch')
-        .withArgs('release-please-config.json', 'main')
+        .withArgs('release-please-config.json', 'next')
         .resolves(buildGitHubFileRaw(JSON.stringify(config)))
-        .withArgs('.release-please-manifest.json', 'main')
+        .withArgs('.release-please-manifest.json', 'next')
         .resolves(
           buildGitHubFileRaw(
             JSON.stringify({
@@ -2828,7 +2855,7 @@ version = "3.0.0"
       const manifest = await Manifest.fromManifest(github, 'main');
       const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(1);
-      expect(pullRequests[0].version?.toString()).to.eql('1.0.0');
+      expect(pullRequests[0].version?.toString()).to.eql('0.0.1');
     });
 
     it('should allow specifying a last release sha', async () => {
@@ -2921,7 +2948,7 @@ version = "3.0.0"
       const manifest = await Manifest.fromManifest(github, 'main');
       const pullRequests = await manifest.buildPullRequests([], []);
       expect(pullRequests).lengthOf(1);
-      expect(pullRequests[0].version?.toString()).to.eql('1.0.0');
+      expect(pullRequests[0].version?.toString()).to.eql('0.0.1');
     });
 
     it('should allow customizing pull request title with root package', async () => {

--- a/test/strategies/dart.ts
+++ b/test/strategies/dart.ts
@@ -51,7 +51,7 @@ describe('Dart', () => {
       ),
     ];
     it('returns release PR changes with defaultInitialVersion', async () => {
-      const expectedVersion = '1.0.0';
+      const expectedVersion = '0.0.1';
       const strategy = new Dart({
         targetBranch: 'main',
         github,

--- a/test/strategies/dotnet-yoshi.ts
+++ b/test/strategies/dotnet-yoshi.ts
@@ -62,9 +62,9 @@ describe('DotnetYoshi', () => {
         .resolves(buildGitHubFileContent(fixturesPath, 'apis.json'));
     });
     it('returns release PR changes with defaultInitialVersion', async () => {
-      const expectedVersion = '1.0.0';
+      const expectedVersion = '0.0.1';
       const expectedTitle =
-        'Release Google.Cloud.SecurityCenter.V1 version 1.0.0';
+        'Release Google.Cloud.SecurityCenter.V1 version 0.0.1';
       const strategy = new DotnetYoshi({
         targetBranch: 'main',
         github,

--- a/test/strategies/elixir.ts
+++ b/test/strategies/elixir.ts
@@ -46,7 +46,7 @@ describe('Elixir', () => {
   });
   describe('buildReleasePullRequest', () => {
     it('returns release PR changes with defaultInitialVersion', async () => {
-      const expectedVersion = '1.0.0';
+      const expectedVersion = '0.0.1';
       const strategy = new Elixir({
         targetBranch: 'main',
         github,

--- a/test/strategies/expo.ts
+++ b/test/strategies/expo.ts
@@ -57,7 +57,7 @@ describe('Expo', () => {
 
   describe('buildReleasePullRequest', () => {
     it('returns release PR changes with defaultInitialVersion', async () => {
-      const expectedVersion = '1.0.0';
+      const expectedVersion = '0.0.1';
 
       const getFileContentsStub = sandbox.stub(
         github,

--- a/test/strategies/go-yoshi.ts
+++ b/test/strategies/go-yoshi.ts
@@ -49,7 +49,7 @@ describe('GoYoshi', () => {
   });
   describe('buildReleasePullRequest', () => {
     it('returns release PR changes with defaultInitialVersion', async () => {
-      const expectedVersion = '0.1.0';
+      const expectedVersion = '0.0.1';
       const strategy = new GoYoshi({
         targetBranch: 'main',
         github,

--- a/test/strategies/go.ts
+++ b/test/strategies/go.ts
@@ -49,7 +49,7 @@ describe('Go', () => {
   });
   describe('buildReleasePullRequest', () => {
     it('returns release PR changes with defaultInitialVersion', async () => {
-      const expectedVersion = '1.0.0';
+      const expectedVersion = '0.0.1';
       const strategy = new Go({
         targetBranch: 'main',
         github,

--- a/test/strategies/helm.ts
+++ b/test/strategies/helm.ts
@@ -51,7 +51,7 @@ describe('Helm', () => {
   });
   describe('buildReleasePullRequest', () => {
     it('returns release PR changes with defaultInitialVersion', async () => {
-      const expectedVersion = '1.0.0';
+      const expectedVersion = '0.0.1';
       const strategy = new Helm({
         targetBranch: 'main',
         github,

--- a/test/strategies/java-yoshi-mono-repo.ts
+++ b/test/strategies/java-yoshi-mono-repo.ts
@@ -65,7 +65,7 @@ describe('JavaYoshiMonoRepo', () => {
   });
   describe('buildReleasePullRequest', () => {
     it('returns release PR changes with defaultInitialVersion', async () => {
-      const expectedVersion = '0.1.0';
+      const expectedVersion = '0.0.1';
       const strategy = new JavaYoshiMonoRepo({
         targetBranch: 'main',
         github,

--- a/test/strategies/java-yoshi.ts
+++ b/test/strategies/java-yoshi.ts
@@ -58,7 +58,7 @@ describe('JavaYoshi', () => {
   });
   describe('buildReleasePullRequest', () => {
     it('returns release PR changes with defaultInitialVersion', async () => {
-      const expectedVersion = '0.1.0';
+      const expectedVersion = '0.0.1';
       const strategy = new JavaYoshi({
         targetBranch: 'main',
         github,

--- a/test/strategies/java.ts
+++ b/test/strategies/java.ts
@@ -70,8 +70,8 @@ describe('Java', () => {
           labels: DEFAULT_LABELS,
         });
 
-        expect(release?.version?.toString()).to.eql('1.0.0');
-        expect(release?.title.toString()).to.eql('chore(main): release 1.0.0');
+        expect(release?.version?.toString()).to.eql('0.0.1');
+        expect(release?.title.toString()).to.eql('chore(main): release 0.0.1');
         expect(release?.headRefName).to.eql('release-please--branches--main');
         expect(release?.draft).to.eql(false);
         expect(release?.labels).to.eql(DEFAULT_LABELS);
@@ -323,9 +323,9 @@ describe('Java', () => {
           labels: DEFAULT_LABELS,
         });
 
-        expect(release?.version?.toString()).to.eql('1.0.0');
+        expect(release?.version?.toString()).to.eql('0.0.1');
         expect(release?.title.toString()).to.eql(
-          'chore(main): release test-sample 1.0.0'
+          'chore(main): release test-sample 0.0.1'
         );
         expect(release?.headRefName).to.eql(
           'release-please--branches--main--components--test-sample'

--- a/test/strategies/krm-blueprint.ts
+++ b/test/strategies/krm-blueprint.ts
@@ -52,7 +52,7 @@ describe('KRMBlueprint', () => {
   });
   describe('buildReleasePullRequest', () => {
     it('returns release PR changes with defaultInitialVersion', async () => {
-      const expectedVersion = '0.1.0';
+      const expectedVersion = '0.0.1';
       const strategy = new KRMBlueprint({
         targetBranch: 'main',
         github,

--- a/test/strategies/maven.ts
+++ b/test/strategies/maven.ts
@@ -66,7 +66,7 @@ describe('Maven', () => {
         latestRelease: undefined,
       });
 
-      expect(release?.version?.toString()).to.eql('1.0.0');
+      expect(release?.version?.toString()).to.eql('0.0.1');
 
       const updates = release!.updates;
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);

--- a/test/strategies/node.ts
+++ b/test/strategies/node.ts
@@ -62,7 +62,7 @@ describe('Node', () => {
   });
   describe('buildReleasePullRequest', () => {
     it('returns release PR changes with defaultInitialVersion', async () => {
-      const expectedVersion = '1.0.0';
+      const expectedVersion = '0.0.1';
       const strategy = new Node({
         targetBranch: 'main',
         github,

--- a/test/strategies/ocaml.ts
+++ b/test/strategies/ocaml.ts
@@ -57,7 +57,7 @@ describe('OCaml', () => {
   });
   describe('buildReleasePullRequest', () => {
     it('returns release PR changes with defaultInitialVersion', async () => {
-      const expectedVersion = '1.0.0';
+      const expectedVersion = '0.0.1';
       const strategy = new OCaml({
         targetBranch: 'main',
         github,

--- a/test/strategies/php-yoshi.ts
+++ b/test/strategies/php-yoshi.ts
@@ -81,7 +81,7 @@ describe('PHPYoshi', () => {
   });
   describe('buildReleasePullRequest', () => {
     it('returns release PR changes with defaultInitialVersion', async () => {
-      const expectedVersion = '1.0.0';
+      const expectedVersion = '0.0.1';
       const strategy = new PHPYoshi({
         targetBranch: 'main',
         github,

--- a/test/strategies/php.ts
+++ b/test/strategies/php.ts
@@ -50,7 +50,7 @@ describe('PHP', () => {
   });
   describe('buildReleasePullRequest', () => {
     it('returns release PR changes with defaultInitialVersion', async () => {
-      const expectedVersion = '1.0.0';
+      const expectedVersion = '0.0.1';
       const strategy = new PHP({
         targetBranch: 'main',
         github,

--- a/test/strategies/python.ts
+++ b/test/strategies/python.ts
@@ -61,7 +61,7 @@ describe('Python', () => {
   });
   describe('buildReleasePullRequest', () => {
     it('returns release PR changes with defaultInitialVersion', async () => {
-      const expectedVersion = '0.1.0';
+      const expectedVersion = '0.0.1';
       const strategy = new Python({
         targetBranch: 'main',
         github,

--- a/test/strategies/ruby-yoshi.ts
+++ b/test/strategies/ruby-yoshi.ts
@@ -52,7 +52,7 @@ describe('RubyYoshi', () => {
   });
   describe('buildReleasePullRequest', () => {
     it('returns release PR changes with defaultInitialVersion', async () => {
-      const expectedVersion = '1.0.0';
+      const expectedVersion = '0.0.1';
       const strategy = new RubyYoshi({
         targetBranch: 'main',
         github,

--- a/test/strategies/ruby.ts
+++ b/test/strategies/ruby.ts
@@ -52,7 +52,7 @@ describe('Ruby', () => {
   });
   describe('buildReleasePullRequest', () => {
     it('returns release PR changes with defaultInitialVersion', async () => {
-      const expectedVersion = '1.0.0';
+      const expectedVersion = '0.0.1';
       const strategy = new Ruby({
         targetBranch: 'main',
         github,

--- a/test/strategies/rust.ts
+++ b/test/strategies/rust.ts
@@ -53,7 +53,7 @@ describe('Rust', () => {
   });
   describe('buildReleasePullRequest', () => {
     it('returns release PR changes with defaultInitialVersion', async () => {
-      const expectedVersion = '0.1.0';
+      const expectedVersion = '0.0.1';
       const strategy = new Rust({
         targetBranch: 'main',
         github,

--- a/test/strategies/sfdx.ts
+++ b/test/strategies/sfdx.ts
@@ -53,7 +53,7 @@ describe('Sfdx', () => {
   });
   describe('buildReleasePullRequest', () => {
     it('returns release PR changes with defaultInitialVersion', async () => {
-      const expectedVersion = '1.0.0';
+      const expectedVersion = '0.0.1';
       const strategy = new Sfdx({
         targetBranch: 'main',
         github,

--- a/test/strategies/simple.ts
+++ b/test/strategies/simple.ts
@@ -50,7 +50,7 @@ describe('Simple', () => {
   });
   describe('buildReleasePullRequest', () => {
     it('returns release PR changes with defaultInitialVersion', async () => {
-      const expectedVersion = '1.0.0';
+      const expectedVersion = '0.0.1';
       const strategy = new Simple({
         targetBranch: 'main',
         github,

--- a/test/strategies/terraform-module.ts
+++ b/test/strategies/terraform-module.ts
@@ -51,7 +51,7 @@ describe('TerraformModule', () => {
   });
   describe('buildReleasePullRequest', () => {
     it('returns release PR changes with defaultInitialVersion', async () => {
-      const expectedVersion = '0.1.0';
+      const expectedVersion = '0.0.1';
       const strategy = new TerraformModule({
         targetBranch: 'main',
         github,


### PR DESCRIPTION
When using release-please with `--change-branch=next` against a new repository where no manifest or config has been merged to `main` yet, we get an error:

```
/home/sam/stainless/stainless/gh-app/node_modules/@stainless-api/release-please/src/manifest.ts:1596
      throw new ConfigurationError(
            ^
ConfigurationError: base (DefinitelyATestOrg/sdk-node): Missing required manifest config: release-please-config.json
    at fetchManifestConfig (/home/sam/stainless/stainless/gh-app/node_modules/@stainless-api/release-please/src/manifest.ts:1596:13)
    at async parseConfig (/home/sam/stainless/stainless/gh-app/node_modules/@stainless-api/release-please/src/manifest.ts:1541:18)
    at async Promise.all (index 0)
    at async Function.fromManifest (/home/sam/stainless/stainless/gh-app/node_modules/@stainless-api/release-please/src/manifest.ts:417:9)
    at async runReleasePlease (/home/sam/stainless/stainless/gh-app/src/helpers/run-release-please.ts:47:20) {
  releaserName: 'base',
  repository: 'DefinitelyATestOrg/sdk-node'
}
```

My [test repositor](https://github.com/DefinitelyATestOrg/sdk-node) has a `next` branch with a manifest, but no release has been created yet, so `main` is just an "Initial commit".

The way upstream release-please generally work is that a `release-please bootstrap` command is first run to generate a default manifest and config. But in the context of Stainless that step isn't necessary, content pushed to `next` will always have release-please config files, we just need to be sure `release-please` is looking at the correct branch. Given that `next` is always supposed to be based on top of `main` we can consider its manifest as up to date.