### PR TITLE
After creating releases wait for GitHub to propagate changes

### DIFF
--- a/__snapshots__/manifest.js
+++ b/__snapshots__/manifest.js
@@ -227,5 +227,6 @@ To set a custom version be sure to use the [semantic versioning format](https://
 `
 
 exports['Manifest createReleases should throw when release branch is missing and changes-branch not in synced with target-branch 1'] = `
-Branch 'next' cannot be safely re-aligned with 'main', and will likely result in git conflicts when the next release PR is created. Hint: compare branches 'release-please--branches--main--changes--next', 'next', and 'main' for inconsistencies
+Errors when aligning pull requests branches: 
+  - Branch 'next' cannot be safely re-aligned with 'main', and will likely result in git conflicts when the next release PR is created. Hint: compare branches 'release-please--branches--main--changes--next', 'next', and 'main' for inconsistencies
 `

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -145,3 +145,10 @@ export function isOctokitGraphqlResponseError(
   }
   return false;
 }
+
+export class AggregateError extends Error {
+  constructor(public errors: Error[], message?: string) {
+    super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -148,7 +148,8 @@ export function isOctokitGraphqlResponseError(
 
 export class AggregateError extends Error {
   constructor(public errors: Error[], message?: string) {
-    super(message);
+    const prefix = message ?? 'AggregateError';
+    super(`${prefix}: ${errors.map(err => `\n  - ${err.message}`)}`);
     Object.setPrototypeOf(this, new.target.prototype);
   }
 }

--- a/src/github.ts
+++ b/src/github.ts
@@ -2224,7 +2224,7 @@ export class GitHub {
 
   async waitForReleaseToBeListed({tagName, id}: GitHubRelease) {
     for (let attempt = 0; attempt < 10; attempt++) {
-      this.logger.warn(
+      this.logger.debug(
         `Checking if release ${tagName} is listed on GitHub (attempt ${
           attempt + 1
         })...`
@@ -2248,7 +2248,7 @@ export class GitHub {
         return;
       }
 
-      await sleepInMs(100 * attempt);
+      await sleepInMs(500 * attempt);
     }
 
     this.logger.warn(`Release ${tagName} is not yet listed on GitHub`);
@@ -2264,7 +2264,7 @@ export class GitHub {
     predicateFn: (fileContent: string) => boolean;
   }) {
     for (let attempt = 0; attempt < 10; attempt++) {
-      this.logger.warn(
+      this.logger.debug(
         `Checking if file ${filePath} on branch ${branch} is up to date on GitHub (attempt ${
           attempt + 1
         })...`
@@ -2273,7 +2273,6 @@ export class GitHub {
       // ensure we are fetching from github directly and update the cache once we find the file to be up to date
       this.invalidateFileCache();
       const file = await this.getFileContentsOnBranch(filePath, branch);
-      this.logger.warn({file});
       const upToDate = predicateFn(file.parsedContent);
       if (upToDate) {
         this.logger.debug(
@@ -2281,7 +2280,7 @@ export class GitHub {
         );
         return;
       }
-      await sleepInMs(100 * attempt);
+      await sleepInMs(500 * attempt);
     }
 
     // cache should be invalidated again to be sure we remove the last item we fetched
@@ -2291,7 +2290,7 @@ export class GitHub {
     );
   }
 
-  private invalidateFileCache() {
+  invalidateFileCache() {
     this.fileCache = new RepositoryFileCache(this.octokit, this.repository);
   }
 }

--- a/src/github.ts
+++ b/src/github.ts
@@ -2221,6 +2221,29 @@ export class GitHub {
       });
     }
   }
+
+  async waitForRelease({url, id}: GitHubRelease) {
+    for (let i = 0; i < 10; i++) {
+      try {
+        this.logger.debug(
+          `Checking if release ${url} is fetchable (attempt ${i + 1})...`
+        );
+        await this.octokit.repos.getRelease({
+          owner: this.repository.owner,
+          repo: this.repository.repo,
+          release_id: id,
+        });
+        this.logger.debug(`Release found`);
+        return;
+      } catch (err: unknown) {
+        if (!isOctokitRequestError(err) || err.status !== 404) {
+          throw err;
+        }
+      }
+    }
+
+    this.logger.debug(`Release ${url} not found`);
+  }
 }
 
 /**

--- a/src/github.ts
+++ b/src/github.ts
@@ -2272,7 +2272,7 @@ export class GitHub {
   }) {
     const maxAttempts = 10;
 
-    let lastError: Error | undefined = undefined;
+    let error: Error | undefined = undefined;
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       this.logger.debug(
         `Checking if file ${filePath} on branch ${branch} is up to date on GitHub (attempt ${
@@ -2282,6 +2282,8 @@ export class GitHub {
 
       // ensure we are fetching from github directly and update the cache once we find the file to be up to date
       this.invalidateFileCache();
+
+      error = undefined;
       try {
         const file = await this.getFileContentsOnBranch(filePath, branch);
         const upToDate = checkFileStatus(file.parsedContent);
@@ -2292,17 +2294,17 @@ export class GitHub {
           return;
         }
       } catch (e: unknown) {
-        lastError = e as Error;
+        error = e as Error;
         this.logger.warn(
           `Failed to fetch ${filePath} on branch ${branch}`,
-          lastError
+          error
         );
       }
       await sleepInMs(500 * attempt);
     }
 
-    if (lastError) {
-      throw lastError;
+    if (error) {
+      throw error;
     }
 
     // cache should be invalidated again to be sure we remove the last item we fetched

--- a/src/github.ts
+++ b/src/github.ts
@@ -2297,7 +2297,6 @@ export class GitHub {
           `Failed to fetch ${filePath} on branch ${branch}`,
           lastError
         );
-        continue;
       }
       await sleepInMs(500 * attempt);
     }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1379,7 +1379,7 @@ export class Manifest {
             return false;
           }
           const path = branchName.getComponent() || '.';
-          return json[path] === version;
+          return json[path] === version.toString();
         },
       });
     }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1423,6 +1423,8 @@ export class Manifest {
       prerelease: release.prerelease,
     });
 
+    await this.github.waitForRelease(githubRelease);
+
     // comment on pull request
     const comment = `:robot: Release is at ${githubRelease.url} :sunflower:`;
     await this.github.commentOnIssue(comment, release.pullRequest.number);

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1373,8 +1373,11 @@ export class Manifest {
       await this.github.waitForFileToBeUpToDateOnBranch({
         branch: branchName.changesBranch,
         filePath: this.manifestPath,
-        predicateFn: (fileContent: string) => {
-          const json = JSON.parse(fileContent) as Record<string, any>;
+        checkFileStatus: arg => {
+          if (arg.kind === 'error') {
+            throw arg.error;
+          }
+          const json = JSON.parse(arg.fileContent) as Record<string, any>;
           if (!json) {
             return false;
           }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1390,11 +1390,8 @@ export class Manifest {
     await this.github.waitForFileToBeUpToDateOnBranch({
       branch: branchName.changesBranch,
       filePath: this.manifestPath,
-      checkFileStatus: arg => {
-        if (arg.kind === 'error') {
-          throw arg.error;
-        }
-        const json = JSON.parse(arg.fileContent) as Record<string, unknown>;
+      checkFileStatus: fileContent => {
+        const json = JSON.parse(fileContent) as Record<string, unknown>;
         if (!json) {
           return false;
         }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1394,12 +1394,19 @@ export class Manifest {
         if (arg.kind === 'error') {
           throw arg.error;
         }
-        const json = JSON.parse(arg.fileContent) as Record<string, any>;
+        const json = JSON.parse(arg.fileContent) as Record<string, unknown>;
         if (!json) {
           return false;
         }
         const path = branchName.getComponent() || '.';
-        return json[path] === version.toString();
+        const val = json[path];
+        if (typeof val !== 'string') {
+          this.logger.error(
+            `Value of manifest file ${this.manifestPath} at key '${path}' was not a string. value=${val}`
+          );
+          return false;
+        }
+        return val === version.toString();
       },
     });
   }

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -5390,17 +5390,15 @@ version = "3.0.0"
           },
         ]
       );
-      const getFileContentsStub = sandbox.stub(
-        github,
-        'getFileContentsOnBranch'
-      );
-      getFileContentsStub
+      const getFileContentsStub = sandbox
+        .stub(github, 'getFileContentsOnBranch')
         .withArgs('package.json', 'main')
         .resolves(
           buildGitHubFileRaw(
             JSON.stringify({name: '@google-cloud/release-brancher'})
           )
         );
+
       const manifest = new Manifest(
         github,
         'main',
@@ -5413,6 +5411,7 @@ version = "3.0.0"
           '.': Version.parse('1.3.1'),
         }
       );
+
       const releases = await manifest.buildReleases();
       expect(releases).lengthOf(1);
       expect(releases[0].tag.toString()).to.eql('release-brancher-v1.3.1');
@@ -5424,6 +5423,8 @@ version = "3.0.0"
       expect(releases[0].name).to.eql('release-brancher: v1.3.1');
       expect(releases[0].draft).to.be.undefined;
       expect(releases[0].prerelease).to.be.undefined;
+
+      sinon.assert.calledOnce(getFileContentsStub);
     });
 
     it('should handle a multiple manifest release', async () => {
@@ -6414,6 +6415,10 @@ version = "3.0.0"
         .resolves();
       const lockBranchStub = sandbox.stub(github, 'lockBranch').resolves();
       const unlockBranchStub = sandbox.stub(github, 'unlockBranch').resolves();
+      const waitForReleaseToBeListedStub = sandbox
+        .stub(github, 'waitForReleaseToBeListed')
+        .resolves();
+
       const manifest = new Manifest(
         github,
         'main',
@@ -6443,6 +6448,10 @@ version = "3.0.0"
         ['autorelease: pending'],
         1234
       );
+      sinon.assert.calledOnceWithExactly(
+        waitForReleaseToBeListedStub,
+        sinon.match.has('tagName', 'release-brancher-v1.3.1')
+      );
       sinon.assert.calledOnce(lockBranchStub);
       sinon.assert.calledOnce(unlockBranchStub);
     });
@@ -6469,11 +6478,8 @@ version = "3.0.0"
           },
         ]
       );
-      const getFileContentsStub = sandbox.stub(
-        github,
-        'getFileContentsOnBranch'
-      );
-      getFileContentsStub
+      const getFileContentsStub = sandbox
+        .stub(github, 'getFileContentsOnBranch')
         .withArgs('packages/bot-config-utils/package.json', 'main')
         .resolves(
           buildGitHubFileRaw(
@@ -6509,6 +6515,9 @@ version = "3.0.0"
       const addLabelsStub = sandbox.stub(github, 'addIssueLabels').resolves();
       const removeLabelsStub = sandbox
         .stub(github, 'removeIssueLabels')
+        .resolves();
+      const waitForReleaseToBeListedStub = sandbox
+        .stub(github, 'waitForReleaseToBeListed')
         .resolves();
       const lockBranchStub = sandbox.stub(github, 'lockBranch').resolves();
       const unlockBranchStub = sandbox.stub(github, 'unlockBranch').resolves();
@@ -6565,8 +6574,25 @@ version = "3.0.0"
         ['autorelease: pending'],
         1234
       );
+      sinon.assert.calledWith(
+        waitForReleaseToBeListedStub,
+        sinon.match.has('tagName', 'bot-config-utils-v3.2.0')
+      );
+      sinon.assert.calledWith(
+        waitForReleaseToBeListedStub,
+        sinon.match.has('tagName', 'label-utils-v1.1.0')
+      );
+      sinon.assert.calledWith(
+        waitForReleaseToBeListedStub,
+        sinon.match.has('tagName', 'object-selector-v1.1.0')
+      );
+      sinon.assert.calledWith(
+        waitForReleaseToBeListedStub,
+        sinon.match.has('tagName', 'datastore-lock-v2.1.0')
+      );
       sinon.assert.calledOnce(lockBranchStub);
       sinon.assert.calledOnce(unlockBranchStub);
+      sinon.assert.calledOnce(getFileContentsStub);
     });
 
     it('should handle a single standalone release', async () => {
@@ -6608,6 +6634,9 @@ version = "3.0.0"
         {id: 123456, sha: 'abc123', tagName: 'v3.2.7'},
       ]);
       const commentStub = sandbox.stub(github, 'commentOnIssue').resolves();
+      const waitForReleaseToBeListedStub = sandbox
+        .stub(github, 'waitForReleaseToBeListed')
+        .resolves();
       const releases = await manifest.createReleases();
       expect(releases).lengthOf(1);
       expect(releases[0]!.tagName).to.eql('v3.2.7');
@@ -6624,6 +6653,10 @@ version = "3.0.0"
         removeLabelsStub,
         ['autorelease: pending'],
         1234
+      );
+      sinon.assert.calledWith(
+        waitForReleaseToBeListedStub,
+        sinon.match.has('tagName', 'v3.2.7')
       );
       sinon.assert.calledOnce(lockBranchStub);
       sinon.assert.calledOnce(unlockBranchStub);
@@ -6665,6 +6698,9 @@ version = "3.0.0"
       const removeLabelsStub = sandbox
         .stub(github, 'removeIssueLabels')
         .resolves();
+      const waitForReleaseToBeListedStub = sandbox
+        .stub(github, 'waitForReleaseToBeListed')
+        .resolves();
       const lockBranchStub = sandbox.stub(github, 'lockBranch').resolves();
       const unlockBranchStub = sandbox.stub(github, 'unlockBranch').resolves();
       const manifest = new Manifest(
@@ -6699,6 +6735,10 @@ version = "3.0.0"
         removeLabelsStub,
         ['some-pull-request-label'],
         1234
+      );
+      sinon.assert.calledWith(
+        waitForReleaseToBeListedStub,
+        sinon.match.has('tagName', 'release-brancher-v1.3.1')
       );
       sinon.assert.calledOnce(lockBranchStub);
       sinon.assert.calledOnce(unlockBranchStub);
@@ -6745,6 +6785,9 @@ version = "3.0.0"
       const removeLabelsStub = sandbox
         .stub(github, 'removeIssueLabels')
         .resolves();
+      const waitForReleaseToBeListedStub = sandbox
+        .stub(github, 'waitForReleaseToBeListed')
+        .resolves();
       const lockBranchStub = sandbox.stub(github, 'lockBranch').resolves();
       const unlockBranchStub = sandbox.stub(github, 'unlockBranch').resolves();
       const manifest = new Manifest(
@@ -6780,6 +6823,10 @@ version = "3.0.0"
         removeLabelsStub,
         ['autorelease: pending'],
         1234
+      );
+      sinon.assert.calledWith(
+        waitForReleaseToBeListedStub,
+        sinon.match.has('tagName', 'release-brancher-v1.3.1')
       );
       sinon.assert.calledOnce(lockBranchStub);
       sinon.assert.calledOnce(unlockBranchStub);
@@ -6828,6 +6875,9 @@ version = "3.0.0"
       const removeLabelsStub = sandbox
         .stub(github, 'removeIssueLabels')
         .resolves();
+      const waitForReleaseToBeListedStub = sandbox
+        .stub(github, 'waitForReleaseToBeListed')
+        .resolves();
       const lockBranchStub = sandbox.stub(github, 'lockBranch').resolves();
       const unlockBranchStub = sandbox.stub(github, 'unlockBranch').resolves();
       const manifest = new Manifest(
@@ -6863,6 +6913,10 @@ version = "3.0.0"
         removeLabelsStub,
         ['autorelease: pending'],
         1234
+      );
+      sinon.assert.calledWith(
+        waitForReleaseToBeListedStub,
+        sinon.match.has('tagName', 'release-brancher-v1.3.1-beta1')
       );
       sinon.assert.calledOnce(lockBranchStub);
       sinon.assert.calledOnce(unlockBranchStub);
@@ -6909,6 +6963,9 @@ version = "3.0.0"
       const removeLabelsStub = sandbox
         .stub(github, 'removeIssueLabels')
         .resolves();
+      const waitForReleaseToBeListedStub = sandbox
+        .stub(github, 'waitForReleaseToBeListed')
+        .resolves();
       const lockBranchStub = sandbox.stub(github, 'lockBranch').resolves();
       const unlockBranchStub = sandbox.stub(github, 'unlockBranch').resolves();
       const manifest = new Manifest(
@@ -6944,6 +7001,10 @@ version = "3.0.0"
         removeLabelsStub,
         ['autorelease: pending'],
         1234
+      );
+      sinon.assert.calledWith(
+        waitForReleaseToBeListedStub,
+        sinon.match.has('tagName', 'release-brancher-v1.3.1')
       );
       sinon.assert.calledOnce(lockBranchStub);
       sinon.assert.calledOnce(unlockBranchStub);
@@ -6990,6 +7051,9 @@ version = "3.0.0"
       const removeLabelsStub = sandbox
         .stub(github, 'removeIssueLabels')
         .resolves();
+      const waitForReleaseToBeListedStub = sandbox
+        .stub(github, 'waitForReleaseToBeListed')
+        .resolves();
       const lockBranchStub = sandbox.stub(github, 'lockBranch').resolves();
       const unlockBranchStub = sandbox.stub(github, 'unlockBranch').resolves();
       const manifest = new Manifest(
@@ -7024,6 +7088,10 @@ version = "3.0.0"
         removeLabelsStub,
         ['autorelease: pending'],
         1234
+      );
+      sinon.assert.calledWith(
+        waitForReleaseToBeListedStub,
+        sinon.match.has('tagName', 'release-brancher-v1.3.1')
       );
       sinon.assert.calledOnce(lockBranchStub);
       sinon.assert.calledOnce(unlockBranchStub);
@@ -7097,6 +7165,9 @@ version = "3.0.0"
       const removeLabelsStub = sandbox
         .stub(github, 'removeIssueLabels')
         .resolves();
+      const waitForReleaseToBeListedStub = sandbox
+        .stub(github, 'waitForReleaseToBeListed')
+        .resolves();
       const lockBranchStub = sandbox.stub(github, 'lockBranch').resolves();
       const unlockBranchStub = sandbox.stub(github, 'unlockBranch').resolves();
       const manifest = new Manifest(
@@ -7147,6 +7218,18 @@ version = "3.0.0"
         removeLabelsStub,
         ['autorelease: pending'],
         1234
+      );
+      sinon.assert.calledWith(
+        waitForReleaseToBeListedStub,
+        sinon.match.has('tagName', 'label-utils-v1.1.0')
+      );
+      sinon.assert.calledWith(
+        waitForReleaseToBeListedStub,
+        sinon.match.has('tagName', 'object-selector-v1.1.0')
+      );
+      sinon.assert.calledWith(
+        waitForReleaseToBeListedStub,
+        sinon.match.has('tagName', 'datastore-lock-v2.1.0')
       );
       sinon.assert.calledOnce(lockBranchStub);
       sinon.assert.calledOnce(unlockBranchStub);
@@ -7305,6 +7388,9 @@ version = "3.0.0"
       const removeLabelsStub = sandbox
         .stub(github, 'removeIssueLabels')
         .resolves();
+      const waitForReleaseToBeListedStub = sandbox
+        .stub(github, 'waitForReleaseToBeListed')
+        .resolves();
       const unlockBranchStub = sandbox.stub(github, 'unlockBranch').resolves();
 
       // make the lock branch fail with the relevant permission error
@@ -7364,6 +7450,10 @@ version = "3.0.0"
         ['autorelease: pending'],
         1234
       );
+      sinon.assert.calledWith(
+        waitForReleaseToBeListedStub,
+        sinon.match.has('tagName', 'release-brancher-v1.3.1')
+      );
 
       // ensure we don't try to update permissions rules again given the lock failed
       sinon.assert.notCalled(unlockBranchStub);
@@ -7404,6 +7494,9 @@ version = "3.0.0"
       const addLabelsStub = sandbox.stub(github, 'addIssueLabels').resolves();
       const removeLabelsStub = sandbox
         .stub(github, 'removeIssueLabels')
+        .resolves();
+      const waitForReleaseToBeListedStub = sandbox
+        .stub(github, 'waitForReleaseToBeListed')
         .resolves();
       const unlockBranchStub = sandbox.stub(github, 'unlockBranch').resolves();
 
@@ -7466,6 +7559,10 @@ version = "3.0.0"
         ['autorelease: pending'],
         1234
       );
+      sinon.assert.calledWith(
+        waitForReleaseToBeListedStub,
+        sinon.match.has('tagName', 'release-brancher-v1.3.1')
+      );
 
       // ensure we don't try to update permissions rules again given the lock failed
       sinon.assert.notCalled(unlockBranchStub);
@@ -7480,7 +7577,7 @@ version = "3.0.0"
             headBranchName: 'release-please--branches--main--changes--next',
             baseBranchName: 'main',
             number: 1234,
-            title: 'chore: release main',
+            title: 'chore: release main v1.3.1',
             body: pullRequestBody('release-notes/single-manifest.txt'),
             labels: ['autorelease: pending'],
             files: [],
@@ -7506,6 +7603,12 @@ version = "3.0.0"
       const addLabelsStub = sandbox.stub(github, 'addIssueLabels').resolves();
       const removeLabelsStub = sandbox
         .stub(github, 'removeIssueLabels')
+        .resolves();
+      const waitForReleaseToBeListedStub = sandbox
+        .stub(github, 'waitForReleaseToBeListed')
+        .resolves();
+      const waitForFileToBeUpToDateOnBranch = sandbox
+        .stub(github, 'waitForFileToBeUpToDateOnBranch')
         .resolves();
       const lockBranchStub = sandbox.stub(github, 'lockBranch').resolves();
       const unlockBranchStub = sandbox.stub(github, 'unlockBranch').resolves();
@@ -7557,6 +7660,15 @@ version = "3.0.0"
         ['autorelease: pending'],
         1234
       );
+      sinon.assert.calledWith(
+        waitForReleaseToBeListedStub,
+        sinon.match.has('tagName', 'release-brancher-v1.3.1')
+      );
+      sinon.assert.calledWith(waitForFileToBeUpToDateOnBranch, {
+        branch: 'next',
+        filePath: '.release-please-manifest.json',
+        checkFileStatus: sinon.match.func,
+      });
 
       sinon.assert.calledOnce(isBranchSyncedWithPullRequestCommitsStub);
       sinon.assert.calledOnce(alignBranchWithAnotherStub);
@@ -7600,6 +7712,9 @@ version = "3.0.0"
       const addLabelsStub = sandbox.stub(github, 'addIssueLabels').resolves();
       const removeLabelsStub = sandbox
         .stub(github, 'removeIssueLabels')
+        .resolves();
+      const waitForReleaseToBeListedStub = sandbox
+        .stub(github, 'waitForReleaseToBeListed')
         .resolves();
       const lockBranchStub = sandbox.stub(github, 'lockBranch').resolves();
       const unlockBranchStub = sandbox.stub(github, 'unlockBranch').resolves();
@@ -7680,6 +7795,10 @@ version = "3.0.0"
         ['autorelease: pending'],
         1234
       );
+      sinon.assert.calledWith(
+        waitForReleaseToBeListedStub,
+        sinon.match.has('tagName', 'release-brancher-v1.3.1')
+      );
 
       sinon.assert.calledOnce(isBranchSyncedWithPullRequestCommitsStub);
       sinon.assert.calledOnce(isBranchASyncedWithBStub);
@@ -7724,6 +7843,9 @@ version = "3.0.0"
       const addLabelsStub = sandbox.stub(github, 'addIssueLabels').resolves();
       const removeLabelsStub = sandbox
         .stub(github, 'removeIssueLabels')
+        .resolves();
+      const waitForReleaseToBeListedStub = sandbox
+        .stub(github, 'waitForReleaseToBeListed')
         .resolves();
       const lockBranchStub = sandbox.stub(github, 'lockBranch').resolves();
       const unlockBranchStub = sandbox.stub(github, 'unlockBranch').resolves();
@@ -7806,6 +7928,10 @@ version = "3.0.0"
         removeLabelsStub,
         ['autorelease: pending'],
         1234
+      );
+      sinon.assert.calledWith(
+        waitForReleaseToBeListedStub,
+        sinon.match.has('tagName', 'release-brancher-v1.3.1')
       );
 
       sinon.assert.calledOnce(isBranchSyncedWithPullRequestCommitsStub);


### PR DESCRIPTION
Ok, this one was a real pain to debug and find a reliable way to deal with, I approached it way too optimistic! But it is an important fix to make the release creation more reliable and avoid a whole set of issues that would (and currently does) impact end users.

In short, after creating github releases it takes a little bit of time for new/updated data to be available through GitHub's API. We need to wait a bit before assuming data returned by the API are up to date.

In more details, this pull request implements two mitigations for conditions that occur when chaining multiple release-please commands (in Stainless case, running `createReleases()` directly followed by `createPullRequests()`).

1. We now wait a bit after creating a release to be sure it is returned by `octokit.repos.listReleases()`
2. We also wait a bit after re-aligning `next` on top of `main` to be sure fetching the manifest returns the updated version
3. We also need to be sure we aren't relying on objects with outdated state or data fetched from an old cache after changing git refs

Note that we did not face this problem before [reading the manifest from `next`](https://github.com/stainless-api/release-please/pull/31), I believe this change is what created conditions for this [issue](https://linear.app/stainless/issue/STA-2269/post-apitrigger-release-please-created-unwanted-release-pr-following).

Something else to note is that this pull request in itself doesn't fix the whole issue, we also need changes to be sure we aren't using outdated data when re-using the same manifest object for multiple commands. I have a quick fix for this for the monorepo.

In case you're curious, that's the type of logs I get, from what I've seen it takes 1-3s before `next` content reflects the branch re-alignment:

```
✔ Align source branch 'next' to target branch 'main', commit '68f63fb0ca6b0f8603b02cdaa156b0403809a232'
❯ PATCH /repos/stainless-sdks/sink-go-public/git/refs/heads%2Fnext - 200 in 358ms
❯ Checking if file .release-please-manifest.json on branch next is up to date on GitHub (attempt 1)...
❯ Fetching '.release-please-manifest.json' from branch 'next'
❯ GET /repos/stainless-sdks/sink-go-public/git/trees/next?recursive=true - 200 in 183ms
❯ GET /repos/stainless-sdks/sink-go-public/git/blobs/4b8769fca013d363492496c81329eb8d71ba4b77 - 200 in 265ms
❯ Checking if file .release-please-manifest.json on branch next is up to date on GitHub (attempt 2)...
❯ Fetching '.release-please-manifest.json' from branch 'next'
❯ GET /repos/stainless-sdks/sink-go-public/git/trees/next?recursive=true - 200 in 232ms
❯ GET /repos/stainless-sdks/sink-go-public/git/blobs/1e4fc9c10cfc6cf53d8a476beb8c9c0b50951a1f - 200 in 208ms
❯ File .release-please-manifest.json on branch next seems up to date on GitHub
```