### PR TITLE
fix: pass pull request title pattern when parsing

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1380,7 +1380,12 @@ export class Manifest {
 
     // updating git branches isn't always instant and can take a bit of time to propagate throughout github systems,
     // it is safer to wait a little bit before doing anything else
-    const version = PullRequestTitle.parse(pr.title)?.getVersion();
+    const version = PullRequestTitle.parse(
+      pr.title,
+      this.repositoryConfig[branchName.getComponent() || '.']
+        ?.pullRequestTitlePattern,
+      this.logger
+    )?.getVersion();
     if (!version) {
       this.logger.warn(
         `PR #${pr.number} title missing a version number: '${pr.title}'`

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -324,7 +324,9 @@ export abstract class BaseStrategy implements Strategy {
         `PR already exists for ${existingPullRequest.headBranchName}, checking if PR title edited to set custom version`
       );
       const existingPRTitleVersion = PullRequestTitle.parse(
-        existingPullRequest.title
+        existingPullRequest.title,
+        this.pullRequestTitlePattern,
+        this.logger
       )?.getVersion();
       const hasCustomVersionLabel = existingPullRequest.labels.find(
         label => label === DEFAULT_CUSTOM_VERSION_LABEL


### PR DESCRIPTION
A few places we do not pass the pull request title pattern option when parsing.