### PR TITLE
fix: package.json scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "pnpm": ">=8"
   },
   "scripts": {
-    "build": "tsc",
-    "install": "tsc",
+    "build": "tsc --project tsconfig.json",
+    "prepare": "tsc --project tsconfig.json",
+    "prepack": "tsc --project tsconfig.json",
     "lint": "gts check",
     "fix": "gts fix",
     "start": "ts-node ./src/bin/release-please.ts",


### PR DESCRIPTION
I incorrectly assumed the package.json script `install` was what we needed to build JS sources on install, but in fact it is `prepare`.

Unfortunately `yarn` ignores it and doesn't provide an alternative 🤷. I thought we would be able to avoid building JS sources and get rid of the `release` branch, but that's not the case...