### PR TITLE
Control auto-merge match behaviour for conventional commits

### DIFF
--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -4927,7 +4927,7 @@ version = "3.0.0"
       ]);
     });
 
-    it('enables auto-merge when filters are provided (filters: version bump, commit type, commit scope)', async () => {
+    it('enables auto-merge when filters are provided (filters: version bump, commit type, commit scope, match-all)', async () => {
       const createPullRequestStub = sandbox
         .stub(github, 'createPullRequest')
         .resolves({
@@ -4990,7 +4990,10 @@ version = "3.0.0"
           autoMerge: {
             mergeMethod: 'rebase',
             versionBumpFilter: ['minor'],
-            conventionalCommitFilter: [{type: 'fix', scope: 'api'}],
+            conventionalCommitFilter: {
+              commits: [{type: 'fix', scope: 'api'}],
+              matchBehaviour: 'match-all',
+            },
           },
         }
       );
@@ -5193,7 +5196,7 @@ version = "3.0.0"
       );
     });
 
-    it('enables auto-merge when filters are provided (filters: only commit type)', async () => {
+    it('enables auto-merge when filters are provided (filters: only commit type, match-all)', async () => {
       const createPullRequestStub = sandbox
         .stub(github, 'createPullRequest')
         .resolves({
@@ -5250,7 +5253,10 @@ version = "3.0.0"
           separatePullRequests: true,
           autoMerge: {
             mergeMethod: 'rebase',
-            conventionalCommitFilter: [{type: 'fix'}], // only filter on type
+            conventionalCommitFilter: {
+              commits: [{type: 'fix'}],
+              matchBehaviour: 'match-all',
+            }, // only filter on type
           },
         }
       );
@@ -5417,7 +5423,7 @@ version = "3.0.0"
       );
     });
 
-    it('enables auto-merge when filters are provided (filters: multiple commit filters)', async () => {
+    it('enables auto-merge when filters are provided (filters: build-patch-minor version bump, commit filters, match-at-least-one)', async () => {
       const createPullRequestStub = sandbox
         .stub(github, 'createPullRequest')
         .resolves({
@@ -5467,6 +5473,10 @@ version = "3.0.0"
             releaseType: 'node',
             component: 'pkg5',
           },
+          'path/f': {
+            releaseType: 'node',
+            component: 'pkg6',
+          },
         },
         {
           'path/a': Version.parse('1.0.0'),
@@ -5474,15 +5484,17 @@ version = "3.0.0"
           'path/c': Version.parse('1.0.0'),
           'path/d': Version.parse('1.0.0'),
           'path/e': Version.parse('1.0.0'),
+          'path/f': Version.parse('1.0.0'),
         },
         {
           separatePullRequests: true,
           autoMerge: {
             mergeMethod: 'rebase',
-            conventionalCommitFilter: [
-              {type: 'fix'},
-              {type: 'feat', scope: 'api'},
-            ],
+            versionBumpFilter: ['minor', 'build', 'patch'],
+            conventionalCommitFilter: {
+              matchBehaviour: 'match-at-least-one',
+              commits: [{type: 'fix'}, {type: 'feat', scope: 'api'}],
+            },
           },
         }
       );
@@ -5497,16 +5509,26 @@ version = "3.0.0"
             labels: [],
             headRefName: 'release-please/branches/main/components/a',
             draft: false,
-            version: Version.parse('1.1.0'),
+            version: Version.parse('1.0.1'), // version bump match filter
             previousVersion: Version.parse('1.0.0'),
             conventionalCommits: [
               {
                 type: 'fix', // type match filter
-                scope: 'something', // some scope
+                scope: 'something',
                 notes: [],
                 references: [],
                 sha: 'commit123',
                 message: 'fix(something): something',
+                bareMessage: 'something',
+                breaking: false,
+              },
+              {
+                type: 'ci', // type does not match filter
+                scope: 'something',
+                notes: [],
+                references: [],
+                sha: 'commit123',
+                message: 'ci(something): something',
                 bareMessage: 'something',
                 breaking: false,
               },
@@ -5519,7 +5541,7 @@ version = "3.0.0"
             labels: [],
             headRefName: 'release-please/branches/main/components/b',
             draft: false,
-            version: Version.parse('1.1.0'),
+            version: Version.parse('1.1.0'), // version bump match filter
             previousVersion: Version.parse('1.0.0'),
             conventionalCommits: [
               {
@@ -5532,6 +5554,16 @@ version = "3.0.0"
                 bareMessage: 'something',
                 breaking: false,
               },
+              {
+                type: 'ci', // type does not match filter
+                scope: 'something',
+                notes: [],
+                references: [],
+                sha: 'commit123',
+                message: 'ci(something): something',
+                bareMessage: 'something',
+                breaking: false,
+              },
             ],
           },
           {
@@ -5541,7 +5573,7 @@ version = "3.0.0"
             labels: [],
             headRefName: 'release-please/branches/main/components/c',
             draft: false,
-            version: Version.parse('1.1.0'),
+            version: Version.parse('1.1.0'), // version bump match filter
             previousVersion: Version.parse('1.0.0'),
             conventionalCommits: [
               {
@@ -5554,6 +5586,16 @@ version = "3.0.0"
                 bareMessage: 'something',
                 breaking: false,
               },
+              {
+                type: 'ci', // type does not match filter
+                scope: 'something',
+                notes: [],
+                references: [],
+                sha: 'commit123',
+                message: 'ci(something): something',
+                bareMessage: 'something',
+                breaking: false,
+              },
             ],
           },
           {
@@ -5563,7 +5605,7 @@ version = "3.0.0"
             labels: [],
             headRefName: 'release-please/branches/main/components/d',
             draft: false,
-            version: Version.parse('1.1.0'),
+            version: Version.parse('1.0.1'), // version bump match filter
             previousVersion: Version.parse('1.0.0'),
             conventionalCommits: [
               {
@@ -5576,6 +5618,16 @@ version = "3.0.0"
                 bareMessage: 'something',
                 breaking: false,
               },
+              {
+                type: 'ci', // type does not match filter
+                scope: 'something',
+                notes: [],
+                references: [],
+                sha: 'commit123',
+                message: 'ci(something): something',
+                bareMessage: 'something',
+                breaking: false,
+              },
             ],
           },
           {
@@ -5585,16 +5637,58 @@ version = "3.0.0"
             labels: [],
             headRefName: 'release-please/branches/main/components/e',
             draft: false,
-            version: Version.parse('1.1.0'),
+            version: Version.parse('2.0.0'), // version bump does not match filter
             previousVersion: Version.parse('1.0.0'),
             conventionalCommits: [
               {
-                type: 'fix', // type does match filter
+                type: 'feat', // type match filter
                 scope: 'api',
                 notes: [],
                 references: [],
                 sha: 'commit123',
-                message: 'chore(something): something',
+                message: 'feat(api): something',
+                bareMessage: 'something',
+                breaking: false,
+              },
+              {
+                type: 'feat', // type does match filter
+                scope: 'something', // scope does not match filter
+                notes: [],
+                references: [],
+                sha: 'commit123',
+                message: 'feat(something): something',
+                bareMessage: 'something',
+                breaking: false,
+              },
+            ],
+          },
+          {
+            title: PullRequestTitle.ofTargetBranch('main', 'main'),
+            body: new PullRequestBody([]),
+            updates: [],
+            labels: [],
+            headRefName: 'release-please/branches/main/components/f',
+            draft: false,
+            version: Version.parse('1.1.0'), // version bump match filter
+            previousVersion: Version.parse('1.0.0'),
+            conventionalCommits: [
+              {
+                type: 'chore', // type does not match filter
+                scope: 'api',
+                notes: [],
+                references: [],
+                sha: 'commit123',
+                message: 'chore(api): something',
+                bareMessage: 'something',
+                breaking: false,
+              },
+              {
+                type: 'ci', // type does not match filter
+                scope: 'something',
+                notes: [],
+                references: [],
+                sha: 'commit123',
+                message: 'feat(something): something',
                 bareMessage: 'something',
                 breaking: false,
               },
@@ -5608,11 +5702,11 @@ version = "3.0.0"
 
       const pullRequestNumbers = await manifest.createPullRequests();
 
-      expect(pullRequestNumbers).lengthOf(5);
+      expect(pullRequestNumbers).lengthOf(6);
       sinon.assert.calledOnce(getLabelsStub);
       sinon.assert.calledOnce(createLabelsStub);
 
-      expect(createPullRequestStub.callCount).to.equal(5);
+      expect(createPullRequestStub.callCount).to.equal(6);
       sinon.assert.calledWith(
         createPullRequestStub,
         sinon.match.has(
@@ -5680,7 +5774,21 @@ version = "3.0.0"
         sinon.match.string,
         sinon.match.array,
         sinon.match({
-          autoMerge: {mergeMethod: 'rebase'},
+          autoMerge: undefined,
+        })
+      );
+      sinon.assert.calledWith(
+        createPullRequestStub,
+        sinon.match.has(
+          'headBranchName',
+          'release-please/branches/main/components/f'
+        ),
+        'main',
+        'main',
+        sinon.match.string,
+        sinon.match.array,
+        sinon.match({
+          autoMerge: undefined,
         })
       );
     });


### PR DESCRIPTION
The auto-merge `conventionalCommitFilter` now supports a `matchBehaviour` value to switch between "all commits should match filters" and "at least one commit should match filters".