### PR TITLE
[STA-3429] prerelease: support format that includes a dot

### DIFF
--- a/src/versioning-strategies/prerelease.ts
+++ b/src/versioning-strategies/prerelease.ts
@@ -17,7 +17,7 @@ import {Version} from '../version';
 import {ConventionalCommit} from '..';
 import {VersionUpdater, CustomVersionUpdate} from '../versioning-strategy';
 
-const PRERELEASE_PATTERN = /^(?<type>[a-z]+)(?<number>\d+)$/;
+const PRERELEASE_PATTERN = /^(?<type>[a-z]+)(?<dot>\.)?(?<number>\d+)$/;
 
 class PrereleasePatchVersionUpdate implements VersionUpdater {
   /**
@@ -36,7 +36,8 @@ class PrereleasePatchVersionUpdate implements VersionUpdater {
           numberLength,
           '0'
         );
-        const nextPrerelease = `${match.groups.type}${paddedNextPrereleaseNumber}`;
+        const maybeDot = match.groups.dot ? '.' : '';
+        const nextPrerelease = `${match.groups.type}${maybeDot}${paddedNextPrereleaseNumber}`;
         return new Version(
           version.major,
           version.minor,
@@ -84,7 +85,8 @@ class PrereleaseMinorVersionUpdate implements VersionUpdater {
           numberLength,
           '0'
         );
-        const nextPrerelease = `${match.groups.type}${paddedNextPrereleaseNumber}`;
+        const maybeDot = match.groups.dot ? '.' : '';
+        const nextPrerelease = `${match.groups.type}${maybeDot}${paddedNextPrereleaseNumber}`;
         return new Version(
           version.major,
           nextMinorNumber,
@@ -134,7 +136,8 @@ class PrereleaseMajorVersionUpdate implements VersionUpdater {
           numberLength,
           '0'
         );
-        const nextPrerelease = `${match.groups.type}${paddedNextPrereleaseNumber}`;
+        const maybeDot = match.groups.dot ? '.' : '';
+        const nextPrerelease = `${match.groups.type}${maybeDot}${paddedNextPrereleaseNumber}`;
         return new Version(
           nextMajorNumber,
           nextMinorNumber,

--- a/test/versioning-strategies/prerelease.ts
+++ b/test/versioning-strategies/prerelease.ts
@@ -63,6 +63,7 @@ describe('PrereleaseVersioningStrategy', () => {
       '1.0.1-beta01': '2.0.0-beta01',
       '1.1.0-beta01': '2.0.0-beta01',
       '1.1.1-beta01': '2.0.0-beta01',
+      '1.0.0-beta.0': '1.0.0-beta.1',
     };
     for (const old in expectedBumps) {
       const expected = expectedBumps[old];
@@ -127,6 +128,7 @@ describe('PrereleaseVersioningStrategy', () => {
       '1.0.1-beta01': '1.1.0-beta01',
       '1.1.0-beta01': '1.1.0-beta02',
       '1.1.1-beta01': '1.2.0-beta01',
+      '1.0.0-beta.0': '1.0.0-beta.1',
     };
     for (const old in expectedBumps) {
       const expected = expectedBumps[old];
@@ -182,6 +184,7 @@ describe('PrereleaseVersioningStrategy', () => {
       '1.0.0-beta1': '1.0.0-beta2',
       '1.0.0-beta9': '1.0.0-beta10', // (although that would be unfortunate)
       '1.0.0-beta09': '1.0.0-beta10',
+      '1.0.0-beta.0': '1.0.0-beta.1',
     };
     for (const old in expectedBumps) {
       const expected = expectedBumps[old];


### PR DESCRIPTION
## Summary
Adds support for dots in prerelease strings, `e.g. 0.0.1-alpha.1`

## Test plan
Added test cases