### PR TITLE
Changelog: filter out commits containing 'chore: release '

### DIFF
--- a/__snapshots__/default-changelog-notes.ts.js
+++ b/__snapshots__/default-changelog-notes.ts.js
@@ -54,6 +54,11 @@ exports['DefaultChangelogNotes buildNotes should handle BREAKING CHANGE notes 1'
 
 exports['DefaultChangelogNotes buildNotes should ignore "chore: release" commits 1'] = `
 ## [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
+
+
+### Chores
+
+* some chore ([sha1](https://github.com/googleapis/java-asset/commit/sha1))
 `
 
 exports['DefaultChangelogNotes buildNotes should ignore RELEASE AS notes 1'] = `

--- a/__snapshots__/default-changelog-notes.ts.js
+++ b/__snapshots__/default-changelog-notes.ts.js
@@ -52,6 +52,10 @@ exports['DefaultChangelogNotes buildNotes should handle BREAKING CHANGE notes 1'
 * some bugfix ([sha2](https://github.com/googleapis/java-asset/commit/sha2))
 `
 
+exports['DefaultChangelogNotes buildNotes should ignore "chore: release" commits 1'] = `
+## [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
+`
+
 exports['DefaultChangelogNotes buildNotes should ignore RELEASE AS notes 1'] = `
 ## [1.2.3](https://github.com/googleapis/java-asset/compare/v1.2.2...v1.2.3) (1983-10-10)
 

--- a/src/changelog-notes/default.ts
+++ b/src/changelog-notes/default.ts
@@ -75,7 +75,7 @@ export class DefaultChangelogNotes implements ChangelogNotes {
       this.mainTemplate || preset.writerOpts.mainTemplate;
     const changelogCommits = commits
       // Filter out commits that are just release commits, they shouldn't be part of the changelog
-      .filter(commit => !commit.bareMessage.includes('chore: release '))
+      .filter(commit => !commit.message.includes('chore: release '))
       .map(commit => {
         const notes = commit.notes
           .filter(note => note.title === 'BREAKING CHANGE')

--- a/src/changelog-notes/default.ts
+++ b/src/changelog-notes/default.ts
@@ -73,35 +73,40 @@ export class DefaultChangelogNotes implements ChangelogNotes {
       this.headerPartial || preset.writerOpts.headerPartial;
     preset.writerOpts.mainTemplate =
       this.mainTemplate || preset.writerOpts.mainTemplate;
-    const changelogCommits = commits.map(commit => {
-      const notes = commit.notes
-        .filter(note => note.title === 'BREAKING CHANGE')
-        .map(note =>
-          replaceIssueLink(
-            note,
-            context.host,
-            context.owner,
-            context.repository
-          )
-        );
-      return {
-        body: '', // commit.body,
-        subject: htmlEscape(commit.bareMessage),
-        type: commit.type,
-        scope: commit.scope,
-        notes,
-        references: commit.references,
-        mentions: [],
-        merge: null,
-        revert: null,
-        header: commit.message,
-        footer: commit.notes
-          .filter(note => note.title === 'RELEASE AS')
-          .map(note => `Release-As: ${note.text}`)
-          .join('\n'),
-        hash: commit.sha,
-      };
-    });
+    const changelogCommits = commits
+      // Filter out commits that are just release commits, they shouldn't be part of the changelog
+      .filter(
+        commit => !commit.bareMessage.toLowerCase().includes('chore: release ')
+      )
+      .map(commit => {
+        const notes = commit.notes
+          .filter(note => note.title === 'BREAKING CHANGE')
+          .map(note =>
+            replaceIssueLink(
+              note,
+              context.host,
+              context.owner,
+              context.repository
+            )
+          );
+        return {
+          body: '', // commit.body,
+          subject: htmlEscape(commit.bareMessage),
+          type: commit.type,
+          scope: commit.scope,
+          notes,
+          references: commit.references,
+          mentions: [],
+          merge: null,
+          revert: null,
+          header: commit.message,
+          footer: commit.notes
+            .filter(note => note.title === 'RELEASE AS')
+            .map(note => `Release-As: ${note.text}`)
+            .join('\n'),
+          hash: commit.sha,
+        };
+      });
 
     const result = conventionalChangelogWriter
       .parseArray(changelogCommits, context, preset.writerOpts)

--- a/src/changelog-notes/default.ts
+++ b/src/changelog-notes/default.ts
@@ -75,7 +75,7 @@ export class DefaultChangelogNotes implements ChangelogNotes {
       this.mainTemplate || preset.writerOpts.mainTemplate;
     const changelogCommits = commits
       // Filter out commits that are just release commits, they shouldn't be part of the changelog
-      .filter(commit => !commit.message.includes('chore: release '))
+      .filter(commit => !commit.message.trim().startsWith('chore: release '))
       .map(commit => {
         const notes = commit.notes
           .filter(note => note.title === 'BREAKING CHANGE')

--- a/src/changelog-notes/default.ts
+++ b/src/changelog-notes/default.ts
@@ -75,9 +75,7 @@ export class DefaultChangelogNotes implements ChangelogNotes {
       this.mainTemplate || preset.writerOpts.mainTemplate;
     const changelogCommits = commits
       // Filter out commits that are just release commits, they shouldn't be part of the changelog
-      .filter(
-        commit => !commit.bareMessage.toLowerCase().includes('chore: release ')
-      )
+      .filter(commit => !commit.bareMessage.includes('chore: release '))
       .map(commit => {
         const notes = commit.notes
           .filter(note => note.title === 'BREAKING CHANGE')

--- a/src/changelog-notes/default.ts
+++ b/src/changelog-notes/default.ts
@@ -18,6 +18,7 @@ import {
   BuildNotesOptions,
 } from '../changelog-notes';
 import {ConventionalCommit} from '../commit';
+import {logger} from '../util/logger';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const conventionalChangelogWriter = require('conventional-changelog-writer');
@@ -75,7 +76,17 @@ export class DefaultChangelogNotes implements ChangelogNotes {
       this.mainTemplate || preset.writerOpts.mainTemplate;
     const changelogCommits = commits
       // Filter out commits that are just release commits, they shouldn't be part of the changelog
-      .filter(commit => !commit.message.trim().startsWith('chore: release '))
+      .filter(commit => {
+        const shouldIgnore = commit.message
+          .trim()
+          .startsWith('chore: release ');
+        if (shouldIgnore) {
+          logger.debug(
+            `changelog: ignoring commit '${commit.message}' (${commit.sha})`
+          );
+        }
+        return !shouldIgnore;
+      })
       .map(commit => {
         const notes = commit.notes
           .filter(note => note.title === 'BREAKING CHANGE')

--- a/test/changelog-notes/default-changelog-notes.ts
+++ b/test/changelog-notes/default-changelog-notes.ts
@@ -130,6 +130,17 @@ describe('DefaultChangelogNotes', () => {
     it('should ignore "chore: release" commits', async () => {
       const commits = [
         {
+          sha: 'sha1',
+          message: 'chore: some chore',
+          files: ['path1/file1.rb'],
+          type: 'chore',
+          scope: null,
+          bareMessage: 'some chore',
+          notes: [],
+          references: [],
+          breaking: false,
+        },
+        {
           sha: 'sha2',
           message: 'chore: release main',
           files: ['path1/file1.rb'],

--- a/test/changelog-notes/default-changelog-notes.ts
+++ b/test/changelog-notes/default-changelog-notes.ts
@@ -127,6 +127,28 @@ describe('DefaultChangelogNotes', () => {
       expect(notes).to.is.string;
       safeSnapshot(notes);
     });
+    it('should ignore "chore: release" commits', async () => {
+      const commits = [
+        {
+          sha: 'sha2',
+          message: 'chore: release main',
+          files: ['path1/file1.rb'],
+          type: 'chore',
+          scope: null,
+          bareMessage: 'release main',
+          notes: [],
+          references: [],
+          breaking: false,
+        },
+      ];
+      const changelogNotes = new DefaultChangelogNotes();
+      const notes = await changelogNotes.buildNotes(commits, {
+        ...notesOptions,
+        changelogSections: [{type: 'chore', section: 'Chores', hidden: false}],
+      });
+      expect(notes).to.is.string;
+      safeSnapshot(notes);
+    });
     describe('with commit parsing', () => {
       it('should handle a breaking change', async () => {
         const commits = [buildMockCommit('fix!: some bugfix')];


### PR DESCRIPTION
When using multiple packages the commit bumping versions is `chore: release`. Unfortunately because it is a conventional semantic commit itself it seems to be included in changelogs of sub-packages.

An example of this can be seen in [this PR](https://github.com/anthropics/anthropic-sdk-typescript/pull/273):

<img width="740" alt="Screenshot 2024-02-01 at 15 54 19" src="https://github.com/stainless-api/release-please/assets/2451004/96eaae75-a644-4482-896a-0856aa3ba159">

Ideally we would have a cleaner way to avoid any release commit without relying on the title but that would require more capacity than we currently have.