### PR TITLE
Exclude multi-package release commits when building release PRs

### DIFF
--- a/src/changelog-notes/default.ts
+++ b/src/changelog-notes/default.ts
@@ -75,17 +75,15 @@ export class DefaultChangelogNotes implements ChangelogNotes {
     preset.writerOpts.mainTemplate =
       this.mainTemplate || preset.writerOpts.mainTemplate;
     const changelogCommits = commits
-      // Filter out commits that are just release commits, they shouldn't be part of the changelog
+      // Filter out commits that are just release commits for multiple packages, they shouldn't be part of the changelog
       .filter(commit => {
-        const shouldIgnore = commit.message
-          .trim()
-          .startsWith('chore: release ');
-        if (shouldIgnore) {
+        if (commit.message.trim().startsWith('chore: release ')) {
           logger.debug(
-            `changelog: ignoring commit '${commit.message}' (${commit.sha})`
+            `changelog: ignoring commit '${commit.message}' (${commit.sha}). It is a release commit for multi-packages PR.`
           );
+          return false;
         }
-        return !shouldIgnore;
+        return true;
       })
       .map(commit => {
         const notes = commit.notes

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -742,7 +742,12 @@ export class Manifest {
     // Filter out commits that are just release commits for multiple packages
     for (const [path, commits] of Object.entries(commitsPerPath)) {
       commitsPerPath[path] = commits.filter(commit => {
-        if (commit.message.trim().startsWith('chore: release ')) {
+        if (
+          commit.pullRequest?.baseBranchName &&
+          commit.message
+            .trim()
+            .startsWith(`chore: release ${commit.pullRequest.baseBranchName}`)
+        ) {
           this.logger.debug(
             `ignoring release commit for multi-packages PR: '${commit.message}' (${commit.sha})`
           );

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -738,6 +738,20 @@ export class Manifest {
         releaseShasByPath[path]
       );
     }
+
+    // Filter out commits that are just release commits for multiple packages
+    for (const [path, commits] of Object.entries(commitsPerPath)) {
+      commitsPerPath[path] = commits.filter(commit => {
+        if (commit.message.trim().startsWith('chore: release ')) {
+          this.logger.debug(
+            `ignoring release commit for multi-packages PR: '${commit.message}' (${commit.sha})`
+          );
+          return false;
+        }
+        return true;
+      });
+    }
+
     const commitExclude = new CommitExclude(this.repositoryConfig);
     commitsPerPath = commitExclude.excludeCommits(commitsPerPath);
 

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -1969,6 +1969,60 @@ describe('Manifest', () => {
       snapshot(dateSafe(pullRequests[0].body.toString()));
     });
 
+    it('should ignore multiple package release commits', async () => {
+      mockReleases(sandbox, github, [
+        {
+          id: 123456,
+          sha: 'abc123',
+          tagName: 'pkg1-v1.0.0',
+          url: 'https://github.com/fake-owner/fake-repo/releases/tag/pkg1-v1.0.0',
+        },
+        {
+          id: 654321,
+          sha: 'def234',
+          tagName: 'pkg2-v0.2.3',
+          url: 'https://github.com/fake-owner/fake-repo/releases/tag/pkg2-v0.2.3',
+        },
+      ]);
+      mockCommits(sandbox, github, [
+        {
+          sha: 'def234',
+          message: 'chore: release main',
+          files: [],
+          pullRequest: {
+            headBranchName: 'release-please/branches/main',
+            baseBranchName: 'main',
+            number: 123,
+            title: 'chore: release main',
+            body: '',
+            labels: [],
+            files: [],
+            sha: 'def234',
+          },
+        },
+      ]);
+      const manifest = new Manifest(
+        github,
+        'main',
+        {
+          'path/a': {
+            releaseType: 'simple',
+            component: 'pkg1',
+          },
+          'path/b': {
+            releaseType: 'simple',
+            component: 'pkg2',
+          },
+        },
+        {
+          'path/a': Version.parse('1.0.0'),
+          'path/b': Version.parse('0.2.3'),
+        }
+      );
+      const pullRequests = await manifest.buildPullRequests([], []);
+      expect(pullRequests).lengthOf(0);
+    });
+
     it('should allow creating multiple pull requests', async () => {
       mockReleases(sandbox, github, [
         {


### PR DESCRIPTION
We noticed a strange behaviour when creating releases for a repo with multiple packages.

Examples:
- https://github.com/dgellow/anthropic-node-test/pull/6
- https://github.com/dgellow/anthropic-node-test/pull/7
- https://github.com/dgellow/anthropic-node-test/pull/8

Release PRs are opened but with no commit other than the release commit.