### PR TITLE
add updater for python readme

### DIFF
--- a/src/strategies/python.ts
+++ b/src/strategies/python.ts
@@ -26,6 +26,7 @@ import {
 import {PythonFileWithVersion} from '../updaters/python/python-file-with-version';
 import {FileNotFoundError} from '../errors';
 import {filterCommits} from '../util/filter-commits';
+import {PythonReadme} from '../updaters/python/python-readme';
 
 const CHANGELOG_SECTIONS = [
   {type: 'feat', section: 'Features'},
@@ -75,6 +76,14 @@ export class Python extends BaseStrategy {
       path: this.addPath('setup.py'),
       createIfMissing: false,
       updater: new SetupPy({
+        version,
+      }),
+    });
+
+    updates.push({
+      path: this.addPath('README.md'),
+      createIfMissing: false,
+      updater: new PythonReadme({
         version,
       }),
     });

--- a/src/updaters/python/python-readme.ts
+++ b/src/updaters/python/python-readme.ts
@@ -1,0 +1,27 @@
+import {DefaultUpdater} from '../default';
+
+/**
+ * Updates a README.md file
+ */
+export class PythonReadme extends DefaultUpdater {
+  /**
+   * Given initial file contents, return updated contents.
+   * @param {string} content The initial content
+   * @returns {string} The updated content
+   */
+  updateContent(content: string): string {
+    if (this.version.preRelease) {
+      // it's a pre-release, so add the pre-release flag if it's missing
+      return content.replace(
+        /^# install from PyPI\n^pip install (\S+)$/gm,
+        '# install from PyPI\npip install --pre $1'
+      );
+    } else {
+      // it's not a pre-release, so remove the pre-release flag if it's present
+      return content.replace(
+        /^# install from PyPI\n^pip install --pre (\S+)$/gm,
+        '# install from PyPI\npip install $1'
+      );
+    }
+  }
+}

--- a/src/updaters/python/python-readme.ts
+++ b/src/updaters/python/python-readme.ts
@@ -10,17 +10,20 @@ export class PythonReadme extends DefaultUpdater {
    * @returns {string} The updated content
    */
   updateContent(content: string): string {
+    // differs for windows vs. linux/ios
+    const newlineType = content.includes('\r\n') ? '\r\n' : '\n';
+
     if (this.version.preRelease) {
       // it's a pre-release, so add the pre-release flag if it's missing
       return content.replace(
-        /^# install from PyPI\n^pip install (\S+)$/gm,
-        '# install from PyPI\npip install --pre $1'
+        /^# install from PyPI\r?\n^pip install (\S+)$/gm,
+        `# install from PyPI${newlineType}pip install --pre $1`
       );
     } else {
       // it's not a pre-release, so remove the pre-release flag if it's present
       return content.replace(
-        /^# install from PyPI\n^pip install --pre (\S+)$/gm,
-        '# install from PyPI\npip install $1'
+        /^# install from PyPI\r?\n^pip install --pre (\S+)$/gm,
+        `# install from PyPI${newlineType}pip install $1`
       );
     }
   }

--- a/test/updaters/fixtures/README-python-no-pre.md
+++ b/test/updaters/fixtures/README-python-no-pre.md
@@ -1,0 +1,6 @@
+## Installation
+
+```sh
+# install from PyPI
+pip install test-repo
+```

--- a/test/updaters/fixtures/README-python-pre.md
+++ b/test/updaters/fixtures/README-python-pre.md
@@ -1,0 +1,6 @@
+## Installation
+
+```sh
+# install from PyPI
+pip install --pre test-repo
+```

--- a/test/updaters/python-readme.ts
+++ b/test/updaters/python-readme.ts
@@ -1,0 +1,50 @@
+import {readFileSync} from 'fs';
+import {resolve} from 'path';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {Version} from '../../src/version';
+import {PythonReadme} from '../../src/updaters/python/python-readme';
+
+const fixturesPath = './test/updaters/fixtures';
+
+describe('PythonReadme', () => {
+  const withPreFlag = readFileSync(
+    resolve(fixturesPath, 'README-python-pre.md'),
+    'utf8'
+  );
+
+  const withoutPreFlag = readFileSync(
+    resolve(fixturesPath, 'README-python-no-pre.md'),
+    'utf8'
+  );
+
+  it('makes no changes if there is a --pre on the install instructions in a README for a prerelease version', async () => {
+    const readmeUpdater = new PythonReadme({
+      version: Version.parse('0.6.0-alpha.1'),
+    });
+    expect(readmeUpdater.updateContent(withPreFlag)).to.equal(withPreFlag);
+  });
+
+  it('makes no changes if there is no --pre on the install instructions in a README for a non-prerelease version', async () => {
+    const readmeUpdater = new PythonReadme({
+      version: Version.parse('0.6.0'),
+    });
+    expect(readmeUpdater.updateContent(withoutPreFlag)).to.equal(
+      withoutPreFlag
+    );
+  });
+
+  it('adds --pre if there is no --pre on the install instructions in a README for a prerelease version', async () => {
+    const readmeUpdater = new PythonReadme({
+      version: Version.parse('0.6.0-alpha.1'),
+    });
+    expect(readmeUpdater.updateContent(withoutPreFlag)).to.equal(withPreFlag);
+  });
+
+  it('removes --pre if there is a --pre on the install instructions in a README for a non-prerelease version', async () => {
+    const readmeUpdater = new PythonReadme({
+      version: Version.parse('0.6.0'),
+    });
+    expect(readmeUpdater.updateContent(withPreFlag)).to.equal(withoutPreFlag);
+  });
+});


### PR DESCRIPTION
Adds an updater that will ensure that the `--pre` flag in the Python installation instructions stay up-to-date with the version.