### PR TITLE
Update package.json files to include build/schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "files": [
     "build/src",
     "templates",
-    "schemas"
+    "schemas",
+    "build/schemas"
   ],
   "repository": "stainless-api/release-please",
   "keywords": [


### PR DESCRIPTION
For some reason without this, there is a breakage with pnpm 9 via the git install. I think this should fix it, but even if it doesn't I think it's ultra low risk.