### PR TITLE
Revert "do not merge directly if we cannot enable auto-merge (#165)"

### DIFF
--- a/__snapshots__/github.ts.js
+++ b/__snapshots__/github.ts.js
@@ -451,7 +451,7 @@ exports['GitHub createRelease should raise a RequestError for other validation e
   "target_commitish": "abc123"
 }
 
-exports['GitHub enablePullRequestAutoMerge does nothing when an auto-merge given but PR in "clean status" 1'] = {
+exports['GitHub enablePullRequestAutoMerge merges release PR directly when an auto-merge given but "protected branch rules not configured for this branch" 1'] = {
   "query": "query pullRequestId($owner: String!, $repo: String!, $pullRequestNumber: Int!) {\n        repository(name: $repo, owner: $owner) {\n          pullRequest(number: $pullRequestNumber) {\n            id\n          }\n        }\n      }",
   "variables": {
     "owner": "fake",
@@ -460,7 +460,7 @@ exports['GitHub enablePullRequestAutoMerge does nothing when an auto-merge given
   }
 }
 
-exports['GitHub enablePullRequestAutoMerge merges release PR directly when an auto-merge given but "protected branch rules not configured for this branch" 1'] = {
+exports['GitHub enablePullRequestAutoMerge merges release PR directly when an auto-merge given but PR in "clean status" 1'] = {
   "query": "query pullRequestId($owner: String!, $repo: String!, $pullRequestNumber: Int!) {\n        repository(name: $repo, owner: $owner) {\n          pullRequest(number: $pullRequestNumber) {\n            id\n          }\n        }\n      }",
   "variables": {
     "owner": "fake",

--- a/src/github.ts
+++ b/src/github.ts
@@ -2358,7 +2358,7 @@ export class GitHub {
   async enablePullRequestAutoMerge(
     pullRequestNumber: number,
     mergeMethod: MergeMethod
-  ): Promise<'auto-merged' | 'none'> {
+  ): Promise<'auto-merged' | 'direct-merged' | 'none'> {
     try {
       this.logger.debug('Enable PR auto-merge');
       const prId = await this.queryPullRequestId(pullRequestNumber);
@@ -2381,9 +2381,15 @@ export class GitHub {
           )
         ) {
           this.logger.debug(
-            'Auto-merge cannot be enabled - user probably has auto-merge disabled for their repo'
+            'PR can be merged directly, do it instead of via GitHub auto-merge'
           );
-          return 'none';
+          await this.octokit.pulls.merge({
+            owner: this.repository.owner,
+            repo: this.repository.repo,
+            pull_number: pullRequestNumber,
+            merge_method: mergeMethod,
+          });
+          return 'direct-merged';
         } else {
           throw e;
         }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1121,18 +1121,22 @@ export class Manifest {
       }
     );
 
+    let directlyMerged = false;
     const autoMerge = this.pullRequestAutoMergeOption(pullRequest);
     if (autoMerge) {
-      await this.github.enablePullRequestAutoMerge(
+      const result = await this.github.enablePullRequestAutoMerge(
         newPullRequest.number,
         autoMerge.mergeMethod
       );
+      directlyMerged = result === 'direct-merged';
     }
 
-    this.github.addPullRequestReviewers({
-      pullRequestNumber: newPullRequest.number,
-      reviewers: this.reviewers,
-    });
+    if (!directlyMerged) {
+      this.github.addPullRequestReviewers({
+        pullRequestNumber: newPullRequest.number,
+        reviewers: this.reviewers,
+      });
+    }
 
     return newPullRequest;
   }
@@ -1165,18 +1169,22 @@ export class Manifest {
       }
     );
 
+    let directlyMerged = false;
     const autoMerge = this.pullRequestAutoMergeOption(pullRequest);
     if (autoMerge) {
-      await this.github.enablePullRequestAutoMerge(
+      const result = await this.github.enablePullRequestAutoMerge(
         updatedPullRequest.number,
         autoMerge.mergeMethod
       );
+      directlyMerged = result === 'direct-merged';
     }
 
-    this.github.addPullRequestReviewers({
-      pullRequestNumber: updatedPullRequest.number,
-      reviewers: this.reviewers,
-    });
+    if (!directlyMerged) {
+      this.github.addPullRequestReviewers({
+        pullRequestNumber: updatedPullRequest.number,
+        reviewers: this.reviewers,
+      });
+    }
 
     return updatedPullRequest;
   }
@@ -1207,18 +1215,22 @@ export class Manifest {
     // TODO: consider leaving the snooze label
     await this.github.removeIssueLabels([SNOOZE_LABEL], snoozed.number);
 
+    let directlyMerged = false;
     const autoMerge = this.pullRequestAutoMergeOption(pullRequest);
     if (autoMerge) {
-      await this.github.enablePullRequestAutoMerge(
+      const result = await this.github.enablePullRequestAutoMerge(
         updatedPullRequest.number,
         autoMerge.mergeMethod
       );
+      directlyMerged = result === 'direct-merged';
     }
 
-    this.github.addPullRequestReviewers({
-      pullRequestNumber: updatedPullRequest.number,
-      reviewers: this.reviewers,
-    });
+    if (!directlyMerged) {
+      this.github.addPullRequestReviewers({
+        pullRequestNumber: updatedPullRequest.number,
+        reviewers: this.reviewers,
+      });
+    }
 
     return updatedPullRequest;
   }

--- a/test/github.ts
+++ b/test/github.ts
@@ -1271,7 +1271,7 @@ describe('GitHub', () => {
       req.done();
     });
 
-    it('does nothing when an auto-merge given but PR in "clean status"', async () => {
+    it('merges release PR directly when an auto-merge given but PR in "clean status"', async () => {
       const mutatePullRequestEnableAutoMergeStub = sandbox
         .stub(github, <any>'mutatePullRequestEnableAutoMerge') // eslint-disable-line @typescript-eslint/no-explicit-any
         .throws(
@@ -1312,10 +1312,14 @@ describe('GitHub', () => {
               },
             },
           },
-        });
+        })
+        .put('/repos/fake/fake/pulls/123/merge', {
+          merge_method: 'rebase',
+        })
+        .reply(200);
 
       const result = await github.enablePullRequestAutoMerge(123, 'rebase');
-      expect(result).to.equal('none');
+      expect(result).to.equal('direct-merged');
       sinon.assert.calledOnce(mutatePullRequestEnableAutoMergeStub);
       req.done();
     });
@@ -1362,10 +1366,14 @@ describe('GitHub', () => {
               },
             },
           },
-        });
+        })
+        .put('/repos/fake/fake/pulls/123/merge', {
+          merge_method: 'rebase',
+        })
+        .reply(200);
 
       const result = await github.enablePullRequestAutoMerge(123, 'rebase');
-      expect(result).to.equal('none');
+      expect(result).to.equal('direct-merged');
       sinon.assert.calledOnce(mutatePullRequestEnableAutoMergeStub);
       req.done();
     });

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -4995,7 +4995,7 @@ version = "3.0.0"
         });
       const enablePullRequestAutoMergeStub = sandbox
         .stub(github, 'enablePullRequestAutoMerge')
-        .resolves('none');
+        .resolves('direct-merged');
       const addPullRequestReviewersStub = sandbox
         .stub(github, 'addPullRequestReviewers')
         .resolves();
@@ -5228,7 +5228,8 @@ version = "3.0.0"
 
       expect(enablePullRequestAutoMergeStub.callCount).to.equal(1);
 
-      expect(addPullRequestReviewersStub.callCount).to.equal(6);
+      // only called when not auto-merged
+      expect(addPullRequestReviewersStub.callCount).to.equal(5);
     });
 
     it('enables auto-merge when filters are provided (filters: only commit type, match-all)', async () => {
@@ -5245,7 +5246,7 @@ version = "3.0.0"
         });
       const enablePullRequestAutoMergeStub = sandbox
         .stub(github, 'enablePullRequestAutoMerge')
-        .resolves('none');
+        .resolves('direct-merged');
       const addPullRequestReviewersStub = sandbox
         .stub(github, 'addPullRequestReviewers')
         .resolves();
@@ -5417,7 +5418,8 @@ version = "3.0.0"
       );
 
       expect(enablePullRequestAutoMergeStub.callCount).to.equal(3);
-      expect(addPullRequestReviewersStub.callCount).to.equal(4);
+      // only called when not auto-merged
+      expect(addPullRequestReviewersStub.callCount).to.equal(1);
     });
 
     it('enables auto-merge when filters are provided (filters: build-patch-minor version bump, commit filters, match-at-least-one)', async () => {
@@ -5434,7 +5436,7 @@ version = "3.0.0"
         });
       const enablePullRequestAutoMergeStub = sandbox
         .stub(github, 'enablePullRequestAutoMerge')
-        .resolves('none');
+        .resolves('direct-merged');
       const addPullRequestReviewersStub = sandbox
         .stub(github, 'addPullRequestReviewers')
         .resolves();
@@ -5753,7 +5755,8 @@ version = "3.0.0"
       );
 
       expect(enablePullRequestAutoMergeStub.callCount).to.equal(4);
-      expect(addPullRequestReviewersStub.callCount).to.equal(7);
+      // only called when not auto-merged
+      expect(addPullRequestReviewersStub.callCount).to.equal(3);
     });
 
     it('updates an existing pull request', async () => {


### PR DESCRIPTION
This reverts commit 188096b222c53120062c742ddfbad6e8a39f62c0.

That change (https://github.com/stainless-api/release-please/pull/165) was meant to prevent us from merging in cases where the GitHub repo has auto-merge enabled. But it turns out that `mutatePullRequestEnableAutoMerge` fails for some cases even when auto-merge is enabled. Namely, it looks like you cannot enable auto-merge through this endpoint unless you have branch protection rules defined (https://github.com/orgs/community/discussions/53088#discussioncomment-5992953) for some reason.