### PR TITLE
[APP-861] update imports for go versioning

### DIFF
--- a/src/strategies/go-yoshi.ts
+++ b/src/strategies/go-yoshi.ts
@@ -21,6 +21,7 @@ import {TagName} from '../util/tag-name';
 import {Release} from '../release';
 import {VersionGo} from '../updaters/go/version-go';
 import {dirname} from 'path';
+import {GithubImportsGo} from '../updaters/go/github-imports-go';
 
 const CHANGELOG_SECTIONS = [
   {type: 'feat', section: 'Features'},
@@ -69,6 +70,21 @@ export class GoYoshi extends BaseStrategy {
         version,
       }),
     });
+
+    const allFiles = await this.github.findFilesByGlobAndRef(
+      '**/*.go',
+      this.changesBranch
+    );
+
+    for (const file of allFiles) {
+      updates.push({
+        path: this.addPath(file),
+        createIfMissing: false,
+        updater: new GithubImportsGo({
+          version,
+        }),
+      });
+    }
 
     return updates;
   }

--- a/src/strategies/go.ts
+++ b/src/strategies/go.ts
@@ -16,6 +16,7 @@
 import {Changelog} from '../updaters/changelog';
 import {BaseStrategy, BuildUpdatesOptions} from './base';
 import {Update} from '../update';
+import {GithubImportsGo} from '../updaters/go/github-imports-go';
 
 export class Go extends BaseStrategy {
   protected async buildUpdates(
@@ -32,6 +33,21 @@ export class Go extends BaseStrategy {
         changelogEntry: options.changelogEntry,
       }),
     });
+
+    const allFiles = await this.github.findFilesByGlobAndRef(
+      '**/*.go',
+      this.changesBranch
+    );
+
+    for (const file of allFiles) {
+      updates.push({
+        path: this.addPath(file),
+        createIfMissing: true,
+        updater: new GithubImportsGo({
+          version,
+        }),
+      });
+    }
 
     return updates;
   }

--- a/src/updaters/go/github-imports-go.ts
+++ b/src/updaters/go/github-imports-go.ts
@@ -1,0 +1,11 @@
+import {DefaultUpdater} from '../default';
+
+export class GithubImportsGo extends DefaultUpdater {
+  updateContent(content: string): string {
+    return content.replace(
+      /"github\.com\/([^/]+)\/([^/]+)\/v([1-9]\d*)\/(.+)"/g,
+      (_, user, repo, __, path) =>
+        `"github.com/${user}/${repo}/v${this.version.major.toString()}/${path}"`
+    );
+  }
+}

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -2529,6 +2529,9 @@ version = "3.0.0"
         .withArgs('version.py', 'next', 'path/c')
         .resolves([]);
 
+      // need to avoid making a request for go versioning
+      sandbox.stub(github, 'findFilesByGlobAndRef').resolves([]);
+
       const addIssueLabelsStub = sandbox
         .stub(github, 'addIssueLabels')
         .withArgs([DEFAULT_CUSTOM_VERSION_LABEL], 111)

--- a/test/updaters/fixtures/file-with-imports-v2.go
+++ b/test/updaters/fixtures/file-with-imports-v2.go
@@ -1,0 +1,18 @@
+package accounts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/cloudflare/cloudflare-go/v2/internal/apijson"
+	"github.com/cloudflare/cloudflare-go/v2/internal/apiquery"
+	"github.com/cloudflare/cloudflare-go/v2/internal/pagination"
+	"github.com/cloudflare/cloudflare-go/v2/internal/param"
+	"github.com/cloudflare/cloudflare-go/v2/internal/requestconfig"
+	"github.com/cloudflare/cloudflare-go/v2/option"
+	"github.com/cloudflare/cloudflare-go/v2/shared"
+)

--- a/test/updaters/fixtures/file-with-imports-v3.go
+++ b/test/updaters/fixtures/file-with-imports-v3.go
@@ -1,0 +1,18 @@
+package accounts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/cloudflare/cloudflare-go/v3/internal/apijson"
+	"github.com/cloudflare/cloudflare-go/v3/internal/apiquery"
+	"github.com/cloudflare/cloudflare-go/v3/internal/pagination"
+	"github.com/cloudflare/cloudflare-go/v3/internal/param"
+	"github.com/cloudflare/cloudflare-go/v3/internal/requestconfig"
+	"github.com/cloudflare/cloudflare-go/v3/option"
+	"github.com/cloudflare/cloudflare-go/v3/shared"
+)

--- a/test/updaters/go-imports.ts
+++ b/test/updaters/go-imports.ts
@@ -1,0 +1,34 @@
+import {readFileSync} from 'fs';
+import {resolve} from 'path';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {Version} from '../../src/version';
+import {GithubImportsGo} from '../../src/updaters/go/github-imports-go';
+
+const fixturesPath = './test/updaters/fixtures';
+
+describe('GithubImportsGo', () => {
+  const v2File = readFileSync(
+    resolve(fixturesPath, 'file-with-imports-v2.go'),
+    'utf8'
+  );
+
+  const v3File = readFileSync(
+    resolve(fixturesPath, 'file-with-imports-v3.go'),
+    'utf8'
+  );
+
+  it('makes no changes if the new version has a major version of 2', async () => {
+    const readmeUpdater = new GithubImportsGo({
+      version: Version.parse('2.0.0'),
+    });
+    expect(readmeUpdater.updateContent(v2File)).to.equal(v2File);
+  });
+
+  it('updates the version in the imports if the new version has a major version of 3', async () => {
+    const readmeUpdater = new GithubImportsGo({
+      version: Version.parse('3.0.0'),
+    });
+    expect(readmeUpdater.updateContent(v2File)).to.equal(v3File);
+  });
+});


### PR DESCRIPTION
### Summary
- release-please does not do version updates for golang correctly out-of-the-box: for major version bumps it does not handle the change to import statements (e.g. "github.com/cloudflare/cloudflare-go/v2/internal/apijson" -> "github.com/cloudflare/cloudflare-go/v3/internal/apijson")
- this PR adds an updater to update import statements
- i'm using the regex `/"github\.com\/([^/]+)\/([^/]+)\/v([1-9]\d*)\/(.+)"/g` to identify import statements which I think is specific enough to avoid false positives while also covering all cases - but that could use a second pair of eyes

### Test Plan
I added some automated tests. I'll also do a full end-to-end test after I deploy.