### PR TITLE
update go import regex to consider pre v2

### DIFF
--- a/src/updaters/go/github-imports-go.ts
+++ b/src/updaters/go/github-imports-go.ts
@@ -2,9 +2,13 @@ import {DefaultUpdater} from '../default';
 
 export class GithubImportsGo extends DefaultUpdater {
   updateContent(content: string): string {
+    if (this.version.major < 2) {
+      return content;
+    }
+
     return content.replace(
-      /"github\.com\/([^/]+)\/([^/]+)\/v([1-9]\d*)\/(.+)"/g,
-      (_, user, repo, __, path) =>
+      /"github\.com\/([^/]+)\/([^/]+)(\/v([1-9]\d*))?\/(.+)"/g,
+      (_, user, repo, __, ___, path) =>
         `"github.com/${user}/${repo}/v${this.version.major.toString()}/${path}"`
     );
   }

--- a/test/updaters/fixtures/file-with-imports-v1.go
+++ b/test/updaters/fixtures/file-with-imports-v1.go
@@ -1,0 +1,18 @@
+package accounts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/cloudflare/cloudflare-go/internal/apijson"
+	"github.com/cloudflare/cloudflare-go/internal/apiquery"
+	"github.com/cloudflare/cloudflare-go/internal/pagination"
+	"github.com/cloudflare/cloudflare-go/internal/param"
+	"github.com/cloudflare/cloudflare-go/internal/requestconfig"
+	"github.com/cloudflare/cloudflare-go/option"
+	"github.com/cloudflare/cloudflare-go/shared"
+)

--- a/test/updaters/go-imports.ts
+++ b/test/updaters/go-imports.ts
@@ -8,6 +8,11 @@ import {GithubImportsGo} from '../../src/updaters/go/github-imports-go';
 const fixturesPath = './test/updaters/fixtures';
 
 describe('GithubImportsGo', () => {
+  const v1File = readFileSync(
+    resolve(fixturesPath, 'file-with-imports-v1.go'),
+    'utf8'
+  );
+
   const v2File = readFileSync(
     resolve(fixturesPath, 'file-with-imports-v2.go'),
     'utf8'
@@ -18,14 +23,28 @@ describe('GithubImportsGo', () => {
     'utf8'
   );
 
-  it('makes no changes if the new version has a major version of 2', async () => {
+  it('makes no changes if the old version has a major version of 1 and the new version also has a major version of 1', async () => {
+    const readmeUpdater = new GithubImportsGo({
+      version: Version.parse('1.0.0'),
+    });
+    expect(readmeUpdater.updateContent(v1File)).to.equal(v1File);
+  });
+
+  it('updates the version in the imports if the old version has a major version of 1 and the new version has a major version of 2', async () => {
+    const readmeUpdater = new GithubImportsGo({
+      version: Version.parse('2.0.0'),
+    });
+    expect(readmeUpdater.updateContent(v1File)).to.equal(v2File);
+  });
+
+  it('makes no changes if the old version has a major version of 2 and the new version also has a major version of 2', async () => {
     const readmeUpdater = new GithubImportsGo({
       version: Version.parse('2.0.0'),
     });
     expect(readmeUpdater.updateContent(v2File)).to.equal(v2File);
   });
 
-  it('updates the version in the imports if the new version has a major version of 3', async () => {
+  it('updates the version in the imports if the old version has a major version of 2 and the new version has a major version of 3', async () => {
     const readmeUpdater = new GithubImportsGo({
       version: Version.parse('3.0.0'),
     });


### PR DESCRIPTION
When the major version is less than 2, there's no `/vX/` in the import path - this PR updates the import path accordingly