### PR TITLE
improve regex

### DIFF
--- a/src/strategies/go-yoshi.ts
+++ b/src/strategies/go-yoshi.ts
@@ -71,12 +71,18 @@ export class GoYoshi extends BaseStrategy {
       }),
     });
 
-    const allFiles = await this.github.findFilesByGlobAndRef(
+    const goFiles = await this.github.findFilesByGlobAndRef(
       '**/*.go',
       this.changesBranch
     );
 
-    for (const file of allFiles) {
+    // handle code snippets in markdown files as well
+    const mdFiles = await this.github.findFilesByGlobAndRef(
+      '**/*.md',
+      this.changesBranch
+    );
+
+    for (const file of [...goFiles, ...mdFiles]) {
       updates.push({
         path: this.addPath(file),
         createIfMissing: false,

--- a/src/strategies/go.ts
+++ b/src/strategies/go.ts
@@ -34,12 +34,18 @@ export class Go extends BaseStrategy {
       }),
     });
 
-    const allFiles = await this.github.findFilesByGlobAndRef(
+    const goFiles = await this.github.findFilesByGlobAndRef(
       '**/*.go',
       this.changesBranch
     );
 
-    for (const file of allFiles) {
+    // handle code snippets in markdown files as well
+    const mdFiles = await this.github.findFilesByGlobAndRef(
+      '**/*.md',
+      this.changesBranch
+    );
+
+    for (const file of [...goFiles, ...mdFiles]) {
       updates.push({
         path: this.addPath(file),
         createIfMissing: true,

--- a/src/updaters/go/github-imports-go.ts
+++ b/src/updaters/go/github-imports-go.ts
@@ -7,9 +7,11 @@ export class GithubImportsGo extends DefaultUpdater {
     }
 
     return content.replace(
-      /"github\.com\/([^/]+)\/([^/]+)(\/v([1-9]\d*))?\/(.+)"/g,
-      (_, user, repo, __, ___, path) =>
-        `"github.com/${user}/${repo}/v${this.version.major.toString()}/${path}"`
+      /"(https:\/\/pkg.go.dev\/)?github\.com\/([^/]+)\/([^/]+)(\/v([1-9]\d*))?(\/[^"]+)?"/g,
+      (_, prefix, user, repo, ___, ____, path) =>
+        `"${prefix ?? ''}github.com/${user}/${repo}${
+          this.version.major < 2 ? '' : '/v' + this.version.major.toString()
+        }${path ?? ''}"`
     );
   }
 }

--- a/test/strategies/go-yoshi.ts
+++ b/test/strategies/go-yoshi.ts
@@ -47,7 +47,10 @@ describe('GoYoshi', () => {
 
     sandbox
       .stub(github, 'findFilesByGlobAndRef')
-      .resolves(['file-with-imports-v2.go']);
+      .withArgs('**/*.go', 'main')
+      .resolves(['file-with-imports-v2.go'])
+      .withArgs('**/*.md', 'main')
+      .resolves([]);
   });
   afterEach(() => {
     sandbox.restore();

--- a/test/strategies/go.ts
+++ b/test/strategies/go.ts
@@ -47,7 +47,10 @@ describe('Go', () => {
 
     sandbox
       .stub(github, 'findFilesByGlobAndRef')
-      .resolves(['file-with-imports-v2.go']);
+      .withArgs('**/*.go', 'main')
+      .resolves(['file-with-imports-v2.go'])
+      .withArgs('**/*.md', 'main')
+      .resolves([]);
   });
   afterEach(() => {
     sandbox.restore();

--- a/test/updaters/fixtures/file-with-go-snippet-v1.md
+++ b/test/updaters/fixtures/file-with-go-snippet-v1.md
@@ -1,0 +1,1 @@
+- <a href="https://pkg.go.dev/github.com/cloudflare/cloudflare-go/shared">shared</a>.<a href="https://pkg.go.dev/github.com/cloudflare/cloudflare-go/shared#ASNParam">ASNParam</a>

--- a/test/updaters/fixtures/file-with-go-snippet-v2.md
+++ b/test/updaters/fixtures/file-with-go-snippet-v2.md
@@ -1,0 +1,1 @@
+- <a href="https://pkg.go.dev/github.com/cloudflare/cloudflare-go/v2/shared">shared</a>.<a href="https://pkg.go.dev/github.com/cloudflare/cloudflare-go/v2/shared#ASNParam">ASNParam</a>

--- a/test/updaters/fixtures/file-with-go-snippet-v3.md
+++ b/test/updaters/fixtures/file-with-go-snippet-v3.md
@@ -1,0 +1,1 @@
+- <a href="https://pkg.go.dev/github.com/cloudflare/cloudflare-go/v3/shared">shared</a>.<a href="https://pkg.go.dev/github.com/cloudflare/cloudflare-go/v3/shared#ASNParam">ASNParam</a>

--- a/test/updaters/fixtures/file-with-imports-v1.go
+++ b/test/updaters/fixtures/file-with-imports-v1.go
@@ -15,4 +15,5 @@ import (
 	"github.com/cloudflare/cloudflare-go/internal/requestconfig"
 	"github.com/cloudflare/cloudflare-go/option"
 	"github.com/cloudflare/cloudflare-go/shared"
+	"github.com/cloudflare/cloudflare-go"
 )

--- a/test/updaters/fixtures/file-with-imports-v2.go
+++ b/test/updaters/fixtures/file-with-imports-v2.go
@@ -15,4 +15,5 @@ import (
 	"github.com/cloudflare/cloudflare-go/v2/internal/requestconfig"
 	"github.com/cloudflare/cloudflare-go/v2/option"
 	"github.com/cloudflare/cloudflare-go/v2/shared"
+	"github.com/cloudflare/cloudflare-go/v2"
 )

--- a/test/updaters/fixtures/file-with-imports-v3.go
+++ b/test/updaters/fixtures/file-with-imports-v3.go
@@ -15,4 +15,5 @@ import (
 	"github.com/cloudflare/cloudflare-go/v3/internal/requestconfig"
 	"github.com/cloudflare/cloudflare-go/v3/option"
 	"github.com/cloudflare/cloudflare-go/v3/shared"
+	"github.com/cloudflare/cloudflare-go/v3"
 )

--- a/test/updaters/go-imports.ts
+++ b/test/updaters/go-imports.ts
@@ -8,46 +8,93 @@ import {GithubImportsGo} from '../../src/updaters/go/github-imports-go';
 const fixturesPath = './test/updaters/fixtures';
 
 describe('GithubImportsGo', () => {
-  const v1File = readFileSync(
-    resolve(fixturesPath, 'file-with-imports-v1.go'),
-    'utf8'
-  );
+  describe('.go files', () => {
+    const v1File = readFileSync(
+      resolve(fixturesPath, 'file-with-imports-v1.go'),
+      'utf8'
+    );
 
-  const v2File = readFileSync(
-    resolve(fixturesPath, 'file-with-imports-v2.go'),
-    'utf8'
-  );
+    const v2File = readFileSync(
+      resolve(fixturesPath, 'file-with-imports-v2.go'),
+      'utf8'
+    );
 
-  const v3File = readFileSync(
-    resolve(fixturesPath, 'file-with-imports-v3.go'),
-    'utf8'
-  );
+    const v3File = readFileSync(
+      resolve(fixturesPath, 'file-with-imports-v3.go'),
+      'utf8'
+    );
 
-  it('makes no changes if the old version has a major version of 1 and the new version also has a major version of 1', async () => {
-    const readmeUpdater = new GithubImportsGo({
-      version: Version.parse('1.0.0'),
+    it('makes no changes if the old version has a major version of 1 and the new version also has a major version of 1', async () => {
+      const importsUpdater = new GithubImportsGo({
+        version: Version.parse('1.0.0'),
+      });
+      expect(importsUpdater.updateContent(v1File)).to.equal(v1File);
     });
-    expect(readmeUpdater.updateContent(v1File)).to.equal(v1File);
+
+    it('updates the version in the imports if the old version has a major version of 1 and the new version has a major version of 2', async () => {
+      const importsUpdater = new GithubImportsGo({
+        version: Version.parse('2.0.0'),
+      });
+      expect(importsUpdater.updateContent(v1File)).to.equal(v2File);
+    });
+
+    it('makes no changes if the old version has a major version of 2 and the new version also has a major version of 2', async () => {
+      const importsUpdater = new GithubImportsGo({
+        version: Version.parse('2.0.0'),
+      });
+      expect(importsUpdater.updateContent(v2File)).to.equal(v2File);
+    });
+
+    it('updates the version in the imports if the old version has a major version of 2 and the new version has a major version of 3', async () => {
+      const importsUpdater = new GithubImportsGo({
+        version: Version.parse('3.0.0'),
+      });
+      expect(importsUpdater.updateContent(v2File)).to.equal(v3File);
+    });
   });
 
-  it('updates the version in the imports if the old version has a major version of 1 and the new version has a major version of 2', async () => {
-    const readmeUpdater = new GithubImportsGo({
-      version: Version.parse('2.0.0'),
-    });
-    expect(readmeUpdater.updateContent(v1File)).to.equal(v2File);
-  });
+  describe('.md files', () => {
+    const v1MdFile = readFileSync(
+      resolve(fixturesPath, 'file-with-go-snippet-v1.md'),
+      'utf8'
+    );
 
-  it('makes no changes if the old version has a major version of 2 and the new version also has a major version of 2', async () => {
-    const readmeUpdater = new GithubImportsGo({
-      version: Version.parse('2.0.0'),
-    });
-    expect(readmeUpdater.updateContent(v2File)).to.equal(v2File);
-  });
+    const v2MdFile = readFileSync(
+      resolve(fixturesPath, 'file-with-go-snippet-v2.md'),
+      'utf8'
+    );
 
-  it('updates the version in the imports if the old version has a major version of 2 and the new version has a major version of 3', async () => {
-    const readmeUpdater = new GithubImportsGo({
-      version: Version.parse('3.0.0'),
+    const v3MdFile = readFileSync(
+      resolve(fixturesPath, 'file-with-go-snippet-v3.md'),
+      'utf8'
+    );
+
+    it('makes no changes if the old version has a major version of 1 and the new version also has a major version of 1', async () => {
+      const importsUpdater = new GithubImportsGo({
+        version: Version.parse('1.0.0'),
+      });
+      expect(importsUpdater.updateContent(v1MdFile)).to.equal(v1MdFile);
     });
-    expect(readmeUpdater.updateContent(v2File)).to.equal(v3File);
+
+    it('updates the version in the imports if the old version has a major version of 1 and the new version has a major version of 2', async () => {
+      const importsUpdater = new GithubImportsGo({
+        version: Version.parse('2.0.0'),
+      });
+      expect(importsUpdater.updateContent(v1MdFile)).to.equal(v2MdFile);
+    });
+
+    it('makes no changes if the old version has a major version of 2 and the new version also has a major version of 2', async () => {
+      const importsUpdater = new GithubImportsGo({
+        version: Version.parse('2.0.0'),
+      });
+      expect(importsUpdater.updateContent(v2MdFile)).to.equal(v2MdFile);
+    });
+
+    it('updates the version in the imports if the old version has a major version of 2 and the new version has a major version of 3', async () => {
+      const importsUpdater = new GithubImportsGo({
+        version: Version.parse('3.0.0'),
+      });
+      expect(importsUpdater.updateContent(v2MdFile)).to.equal(v3MdFile);
+    });
   });
 });


### PR DESCRIPTION
- handle https://pkg.go.dev cases (e.g. "https://pkg.go.dev/github.com/cloudflare/cloudflare-go/shared")
- handles cases with no trailing path after the version (e.g. "github.com/cloudflare/cloudflare-go/v2")