### PR TITLE
improve regex for go version update

### DIFF
--- a/src/updaters/go/github-imports-go.ts
+++ b/src/updaters/go/github-imports-go.ts
@@ -7,7 +7,7 @@ export class GithubImportsGo extends DefaultUpdater {
     }
 
     return content.replace(
-      /"(https:\/\/pkg.go.dev\/)?github\.com\/([^/]+)\/([^/]+)(\/v([1-9]\d*))?(\/[^"]+)?"/g,
+      /"(https:\/\/pkg.go.dev\/)?github\.com\/([^/"\n]+)\/([^/"\n]+)(\/v([1-9]\d*))?(\/[^"\n]+)?"/g,
       (_, prefix, user, repo, ___, ____, path) =>
         `"${prefix ?? ''}github.com/${user}/${repo}${
           this.version.major < 2 ? '' : '/v' + this.version.major.toString()


### PR DESCRIPTION
exclude quotes and newlines to avoid greedily matching extra content (see https://github.com/meorphis/test-repo-15/pull/2/commits/879fb416ecbf8b91a41a388fc36e205f93d09cf8)