### PR TITLE
tie go version updates to specific repo

### DIFF
--- a/src/strategies/go-yoshi.ts
+++ b/src/strategies/go-yoshi.ts
@@ -97,6 +97,7 @@ export class GoYoshi extends BaseStrategy {
         createIfMissing: false,
         updater: new GithubImportsGo({
           version,
+          repository: this.repository,
         }),
       });
     }

--- a/src/strategies/go.ts
+++ b/src/strategies/go.ts
@@ -60,6 +60,7 @@ export class Go extends BaseStrategy {
         createIfMissing: true,
         updater: new GithubImportsGo({
           version,
+          repository: this.repository,
         }),
       });
     }

--- a/src/updaters/go/github-imports-go.ts
+++ b/src/updaters/go/github-imports-go.ts
@@ -1,17 +1,31 @@
+import {Repository} from '@google-automations/git-file-utils';
 import {DefaultUpdater} from '../default';
+import {Version} from '../../version';
 
 export class GithubImportsGo extends DefaultUpdater {
+  private repository: Repository;
+
+  constructor(options: {repository: Repository; version: Version}) {
+    super(options);
+    this.repository = options.repository;
+  }
+
   updateContent(content: string): string {
     if (this.version.major < 2) {
       return content;
     }
 
     return content.replace(
-      /"(https:\/\/pkg.go.dev\/)?github\.com\/([^/"\r?\n]+)\/([^/"\r?\n]+)(\/v([1-9]\d*))?(\/[^"\r?\n]+)?"/g,
-      (_, prefix, user, repo, ___, ____, path) =>
-        `"${prefix ?? ''}github.com/${user}/${repo}${
-          this.version.major < 2 ? '' : '/v' + this.version.major.toString()
-        }${path ?? ''}"`
+      new RegExp(
+        `"(https://pkg.go.dev/)?github.com/${this.repository.owner}/${this.repository.repo}(/v([1-9]\\d*))?(/[^"\\r?\\n]+)?"`,
+        'g'
+      ),
+      (_, prefix, __, ___, path) =>
+        `"${prefix ?? ''}github.com/${this.repository.owner}/${
+          this.repository.repo
+        }${this.version.major < 2 ? '' : '/v' + this.version.major.toString()}${
+          path ?? ''
+        }"`
     );
   }
 }

--- a/test/updaters/go-imports.ts
+++ b/test/updaters/go-imports.ts
@@ -26,6 +26,10 @@ describe('GithubImportsGo', () => {
 
     it('makes no changes if the old version has a major version of 1 and the new version also has a major version of 1', async () => {
       const importsUpdater = new GithubImportsGo({
+        repository: {
+          owner: 'cloudflare',
+          repo: 'cloudflare-go',
+        },
         version: Version.parse('1.0.0'),
       });
       expect(importsUpdater.updateContent(v1File)).to.equal(v1File);
@@ -33,6 +37,10 @@ describe('GithubImportsGo', () => {
 
     it('updates the version in the imports if the old version has a major version of 1 and the new version has a major version of 2', async () => {
       const importsUpdater = new GithubImportsGo({
+        repository: {
+          owner: 'cloudflare',
+          repo: 'cloudflare-go',
+        },
         version: Version.parse('2.0.0'),
       });
       expect(importsUpdater.updateContent(v1File)).to.equal(v2File);
@@ -40,6 +48,10 @@ describe('GithubImportsGo', () => {
 
     it('makes no changes if the old version has a major version of 2 and the new version also has a major version of 2', async () => {
       const importsUpdater = new GithubImportsGo({
+        repository: {
+          owner: 'cloudflare',
+          repo: 'cloudflare-go',
+        },
         version: Version.parse('2.0.0'),
       });
       expect(importsUpdater.updateContent(v2File)).to.equal(v2File);
@@ -47,6 +59,10 @@ describe('GithubImportsGo', () => {
 
     it('updates the version in the imports if the old version has a major version of 2 and the new version has a major version of 3', async () => {
       const importsUpdater = new GithubImportsGo({
+        repository: {
+          owner: 'cloudflare',
+          repo: 'cloudflare-go',
+        },
         version: Version.parse('3.0.0'),
       });
       expect(importsUpdater.updateContent(v2File)).to.equal(v3File);
@@ -71,6 +87,10 @@ describe('GithubImportsGo', () => {
 
     it('makes no changes if the old version has a major version of 1 and the new version also has a major version of 1', async () => {
       const importsUpdater = new GithubImportsGo({
+        repository: {
+          owner: 'cloudflare',
+          repo: 'cloudflare-go',
+        },
         version: Version.parse('1.0.0'),
       });
       expect(importsUpdater.updateContent(v1MdFile)).to.equal(v1MdFile);
@@ -78,6 +98,10 @@ describe('GithubImportsGo', () => {
 
     it('updates the version in the imports if the old version has a major version of 1 and the new version has a major version of 2', async () => {
       const importsUpdater = new GithubImportsGo({
+        repository: {
+          owner: 'cloudflare',
+          repo: 'cloudflare-go',
+        },
         version: Version.parse('2.0.0'),
       });
       expect(importsUpdater.updateContent(v1MdFile)).to.equal(v2MdFile);
@@ -85,6 +109,10 @@ describe('GithubImportsGo', () => {
 
     it('makes no changes if the old version has a major version of 2 and the new version also has a major version of 2', async () => {
       const importsUpdater = new GithubImportsGo({
+        repository: {
+          owner: 'cloudflare',
+          repo: 'cloudflare-go',
+        },
         version: Version.parse('2.0.0'),
       });
       expect(importsUpdater.updateContent(v2MdFile)).to.equal(v2MdFile);
@@ -92,6 +120,10 @@ describe('GithubImportsGo', () => {
 
     it('updates the version in the imports if the old version has a major version of 2 and the new version has a major version of 3', async () => {
       const importsUpdater = new GithubImportsGo({
+        repository: {
+          owner: 'cloudflare',
+          repo: 'cloudflare-go',
+        },
         version: Version.parse('3.0.0'),
       });
       expect(importsUpdater.updateContent(v2MdFile)).to.equal(v3MdFile);


### PR DESCRIPTION
instead of updating the repo version suffix on all repos found in the .go imports, only update the ones for the repo on which release-please is being invoked