### PR TITLE
one more fix to go regex

### DIFF
--- a/src/updaters/go/github-imports-go.ts
+++ b/src/updaters/go/github-imports-go.ts
@@ -17,7 +17,7 @@ export class GithubImportsGo extends DefaultUpdater {
 
     return content.replace(
       new RegExp(
-        `"(https://pkg.go.dev/)?github.com/${this.repository.owner}/${this.repository.repo}(/v([1-9]\\d*))?(/[^"\\r?\\n]+)?"`,
+        `"(https://pkg.go.dev/)?github.com/${this.repository.owner}/${this.repository.repo}(/v([1-9]\\d*))?([^"\\r\\n]+)?"`,
         'g'
       ),
       (_, prefix, __, ___, path) =>


### PR DESCRIPTION
handle the case where there's no slash after the version, e.g. `https://pkg.go.dev/github.com/Modern-Treasury/modern-treasury-go/v2#EventService.Get`