### PR TITLE
increase files per commit limit

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -1294,7 +1294,10 @@ export class GitHub {
           owner: this.repository.owner,
         },
         message,
-        true
+        true,
+        {
+          filesPerCommit: 1000000, // set a really high limit to effectively put all of the files in one commit
+        }
       );
 
       // create pull request, unless one already exists


### PR DESCRIPTION
now that Go SDKs have many (in bigger repos, 100+) file changes for major version updates, we need to increase the filesPerCommit if we want all the changes to be in a single commit