### PR TITLE
Revert "increase files per commit limit (#180)"

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -1294,10 +1294,7 @@ export class GitHub {
           owner: this.repository.owner,
         },
         message,
-        true,
-        {
-          filesPerCommit: 1000000, // set a really high limit to effectively put all of the files in one commit
-        }
+        true
       );
 
       // create pull request, unless one already exists


### PR DESCRIPTION
Setting a higher limit causes the GitHub API to throw a 502, so we can't do this.