### PR TITLE
stop including empty updates in changeset

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -1471,7 +1471,7 @@ export class GitHub {
         contentText,
         this.logger
       );
-      if (updatedContent) {
+      if (updatedContent !== contentText) {
         changes.set(update.path, {
           content: updatedContent,
           originalContent: content?.parsedContent || null,


### PR DESCRIPTION
with Go version changes, we run an updater that goes through every single .go file and looks for changes needed to import files. if nothing changes, we should not include the changes in the changeset - otherwise, we'll end up with empty commits