### PR TITLE
only use go import updaters when there is a major version update

### DIFF
--- a/src/strategies/go.ts
+++ b/src/strategies/go.ts
@@ -35,34 +35,36 @@ export class Go extends BaseStrategy {
       }),
     });
 
-    updates.push({
-      path: this.addPath('go.mod'),
-      createIfMissing: false,
-      updater: new GoModUpdater({
-        version,
-      }),
-    });
-
-    const goFiles = await this.github.findFilesByGlobAndRef(
-      '**/*.go',
-      this.changesBranch
-    );
-
-    // handle code snippets in markdown files as well
-    const mdFiles = await this.github.findFilesByGlobAndRef(
-      '**/*.md',
-      this.changesBranch
-    );
-
-    for (const file of [...goFiles, ...mdFiles]) {
+    if (version.major >= 2 && options.latestVersion?.major !== version.major) {
       updates.push({
-        path: this.addPath(file),
-        createIfMissing: true,
-        updater: new GithubImportsGo({
+        path: this.addPath('go.mod'),
+        createIfMissing: false,
+        updater: new GoModUpdater({
           version,
-          repository: this.repository,
         }),
       });
+
+      const goFiles = await this.github.findFilesByGlobAndRef(
+        '**/*.go',
+        this.changesBranch
+      );
+
+      // handle code snippets in markdown files as well
+      const mdFiles = await this.github.findFilesByGlobAndRef(
+        '**/*.md',
+        this.changesBranch
+      );
+
+      for (const file of [...goFiles, ...mdFiles]) {
+        updates.push({
+          path: this.addPath(file),
+          createIfMissing: true,
+          updater: new GithubImportsGo({
+            version,
+            repository: this.repository,
+          }),
+        });
+      }
     }
 
     return updates;

--- a/test/strategies/go.ts
+++ b/test/strategies/go.ts
@@ -37,6 +37,8 @@ const COMMITS = [
   ...buildMockConventionalCommit('chore: update common templates'),
 ];
 
+const BREAKING_CHANGE = buildMockConventionalCommit('feat!: breaking change');
+
 describe('Go', () => {
   let github: GitHub;
   beforeEach(async () => {
@@ -121,9 +123,13 @@ describe('Go', () => {
           )
         );
       sandbox.stub(github, 'findFilesByFilenameAndRef').resolves([]);
-      const latestRelease = undefined;
+      const latestRelease = {
+        tag: new TagName(Version.parse('1.0.0'), 'some-go-package'),
+        sha: 'abc123',
+        notes: 'some notes',
+      };
       const release = await strategy.buildReleasePullRequest({
-        commits: COMMITS,
+        commits: [...COMMITS, ...BREAKING_CHANGE],
         latestRelease,
       });
       const updates = release!.updates;
@@ -144,9 +150,13 @@ describe('Go', () => {
           )
         );
       sandbox.stub(github, 'findFilesByFilenameAndRef').resolves([]);
-      const latestRelease = undefined;
+      const latestRelease = {
+        tag: new TagName(Version.parse('1.0.0'), 'some-go-package'),
+        sha: 'abc123',
+        notes: 'some notes',
+      };
       const release = await strategy.buildReleasePullRequest({
-        commits: COMMITS,
+        commits: [...COMMITS, ...BREAKING_CHANGE],
         latestRelease,
       });
       const updates = release!.updates;


### PR DESCRIPTION
these only do anything if there's a major version update, so there's no reason to run them otherwise. they are fairly slow because each file results in an API call to github I believe.