### PR TITLE
Add `forcePrerelease` option

### DIFF
--- a/schemas/config.json
+++ b/schemas/config.json
@@ -65,6 +65,10 @@
           "description": "Create the GitHub release as prerelease. Defaults to `false`.",
           "type": "boolean"
         },
+        "forcePrerelease": {
+          "description": "Always create a GitHub prerelease for every release. Defaults to `false`.",
+          "type": "boolean"
+        },
         "draft-pull-request": {
           "description": "Open the release pull request in draft mode. Defaults to `false`.",
           "type": "boolean"

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -86,6 +86,7 @@ interface ManifestConfigArgs {
 interface ReleaseArgs {
   draft?: boolean;
   prerelease?: boolean;
+  forcePrerelease?: boolean;
   releaseLabel?: string;
   prereleaseLabel?: string;
   snapshotLabel?: string;
@@ -580,6 +581,7 @@ const createReleaseCommand: yargs.CommandModule<{}, CreateReleaseArgs> = {
           packageName: argv.packageName,
           draft: argv.draft,
           prerelease: argv.prerelease,
+          forcePrerelease: argv.forcePrerelease,
           includeComponentInTag: argv.monorepoTags,
           includeVInTag: argv.includeVInTags,
         },

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -104,6 +104,7 @@ export interface ReleaserConfig {
   skipGithubRelease?: boolean; // Note this should be renamed to skipGitHubRelease in next major release
   draft?: boolean;
   prerelease?: boolean;
+  forcePrerelease?: boolean;
   draftPullRequest?: boolean;
   component?: string;
   packageName?: string;
@@ -159,6 +160,7 @@ interface ReleaserConfigJson {
   'skip-github-release'?: boolean;
   draft?: boolean;
   prerelease?: boolean;
+  forcePrerelease?: boolean;
   'draft-pull-request'?: boolean;
   label?: string;
   'release-label'?: string;
@@ -200,6 +202,7 @@ export interface ManifestOptions {
   sequentialCalls?: boolean;
   draft?: boolean;
   prerelease?: boolean;
+  forcePrerelease?: boolean;
   draftPullRequest?: boolean;
   groupPullRequestTitlePattern?: string;
   releaseSearchDepth?: number;
@@ -1301,6 +1304,7 @@ export class Manifest {
             draft: config.draft ?? this.draft,
             prerelease:
               hasPrereleaseLabel ||
+              config.forcePrerelease ||
               (config.prerelease && !!release.tag.version.preRelease),
           });
         }
@@ -2136,6 +2140,8 @@ function mergeReleaserConfig(
       pathConfig.skipGithubRelease ?? defaultConfig.skipGithubRelease,
     draft: pathConfig.draft ?? defaultConfig.draft,
     prerelease: pathConfig.prerelease ?? defaultConfig.prerelease,
+    forcePrerelease:
+      pathConfig.forcePrerelease ?? defaultConfig.forcePrerelease,
     component: pathConfig.component ?? defaultConfig.component,
     packageName: pathConfig.packageName ?? defaultConfig.packageName,
     versionFile: pathConfig.versionFile ?? defaultConfig.versionFile,

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -7180,6 +7180,108 @@ version = "3.0.0"
       expect(releases[0].tag.toString()).to.eql('release-brancher-v1.3.1');
     });
 
+    it('should build prerelease releases when forcePrerelease is true', async () => {
+      mockPullRequests(
+        github,
+        [],
+        [
+          {
+            headBranchName: 'release-please/branches/main',
+            baseBranchName: 'main',
+            number: 1234,
+            title: 'chore: release main',
+            body: pullRequestBody(
+              'release-notes/single-manifest-pre-major.txt'
+            ),
+            labels: ['autorelease: pending'],
+            files: [''],
+            sha: 'abc123',
+          },
+        ]
+      );
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('package.json', 'main')
+        .resolves(
+          buildGitHubFileRaw(
+            JSON.stringify({name: '@google-cloud/release-brancher'})
+          )
+        );
+      const manifest = new Manifest(
+        github,
+        'main',
+        {
+          '.': {
+            releaseType: 'node',
+            prerelease: true,
+            forcePrerelease: true,
+          },
+        },
+        {
+          '.': Version.parse('0.1.0'),
+        }
+      );
+      const releases = await manifest.buildReleases();
+      expect(releases).lengthOf(1);
+      expect(releases[0].name).to.eql('release-brancher: v0.2.0');
+      expect(releases[0].draft).to.be.undefined;
+      expect(releases[0].prerelease).to.be.true;
+      expect(releases[0].tag.toString()).to.eql('release-brancher-v0.2.0');
+    });
+
+    it('should build prerelease releases from non-prerelease when forcePrerelease is true', async () => {
+      mockPullRequests(
+        github,
+        [],
+        [
+          {
+            headBranchName: 'release-please/branches/main',
+            baseBranchName: 'main',
+            number: 1234,
+            title: 'chore: release main',
+            body: pullRequestBody('release-notes/single-manifest.txt'),
+            labels: ['autorelease: pending'],
+            files: [''],
+            sha: 'abc123',
+          },
+        ]
+      );
+      const getFileContentsStub = sandbox.stub(
+        github,
+        'getFileContentsOnBranch'
+      );
+      getFileContentsStub
+        .withArgs('package.json', 'main')
+        .resolves(
+          buildGitHubFileRaw(
+            JSON.stringify({name: '@google-cloud/release-brancher'})
+          )
+        );
+      const manifest = new Manifest(
+        github,
+        'main',
+        {
+          '.': {
+            releaseType: 'node',
+            prerelease: true,
+            forcePrerelease: true,
+          },
+        },
+        {
+          '.': Version.parse('1.3.0'),
+        }
+      );
+      const releases = await manifest.buildReleases();
+      expect(releases).lengthOf(1);
+      expect(releases[0].name).to.eql('release-brancher: v1.3.1');
+      expect(releases[0].draft).to.be.undefined;
+      expect(releases[0].prerelease).to.be.true;
+      expect(releases[0].tag.toString()).to.eql('release-brancher-v1.3.1');
+    });
+
     it('should skip component in tag', async () => {
       mockPullRequests(
         github,


### PR DESCRIPTION
Adds an option to always make a `prerelease` release regardless of whether the version is a prerelease. 

This is useful for terraform where we run `goreleaser` upon tag creation and append assets to the release, but don't want the release to be "published" until the assets are built.