### PR TITLE
support auto-merge for pre-release bumps

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -306,7 +306,7 @@ export type AutoMergeOption = {
   /**
    * Only auto merge if the version bump match the filter
    */
-  versionBumpFilter?: ('major' | 'minor' | 'patch' | 'build')[];
+  versionBumpFilter?: ('major' | 'minor' | 'patch' | 'build' | 'preRelease')[];
 };
 
 export class Manifest {

--- a/src/version.ts
+++ b/src/version.ts
@@ -83,7 +83,9 @@ export class Version {
     return `${this.major}.${this.minor}.${this.patch}${preReleasePart}${buildPart}`;
   }
 
-  compareBump(other: Version): 'major' | 'minor' | 'patch' | 'build' | 'none' {
+  compareBump(
+    other: Version
+  ): 'major' | 'minor' | 'patch' | 'build' | 'preRelease' | 'none' {
     if (this.major !== other.major) {
       return 'major';
     }
@@ -95,6 +97,9 @@ export class Version {
     }
     if (this.build !== other.build) {
       return 'build';
+    }
+    if (this.preRelease !== other.preRelease) {
+      return 'preRelease';
     }
     return 'none';
   }


### PR DESCRIPTION
release-please doesn't support auto-merge for prerelease bumps (e.g. 0.1.0-alpha.1 -> 0.1.0-alpha.2) but there's no reason it shouldn't, so I'm adding it to our fork