### PR TITLE
improvements for ruby version updates

### DIFF
--- a/src/strategies/ruby.ts
+++ b/src/strategies/ruby.ts
@@ -50,8 +50,25 @@ export class Ruby extends BaseStrategy {
     const versionFile: string = this.versionFile
       ? this.versionFile
       : `lib/${(this.component || '').replace(/-/g, '/')}/version.rb`;
+
     updates.push({
       path: this.addPath(versionFile),
+      createIfMissing: false,
+      updater: new VersionRB({
+        version,
+      }),
+    });
+
+    updates.push({
+      path: `rbi/${versionFile}i`,
+      createIfMissing: false,
+      updater: new VersionRB({
+        version,
+      }),
+    });
+
+    updates.push({
+      path: `sig/${versionFile}s`,
       createIfMissing: false,
       updater: new VersionRB({
         version,
@@ -63,7 +80,11 @@ export class Ruby extends BaseStrategy {
       createIfMissing: false,
       updater: new GemfileLock({
         version,
-        gemName: this.component || '',
+        gemName:
+          this.component ||
+          // grab the gem name from the version file path if it's not provided via the component
+          this.versionFile.match(/lib\/(.*)\/version.rb/)?.[1] ||
+          '',
       }),
     });
 

--- a/test/strategies/ruby.ts
+++ b/test/strategies/ruby.ts
@@ -97,9 +97,19 @@ describe('Ruby', () => {
         latestRelease,
       });
       const updates = release!.updates;
-      expect(updates).lengthOf(3);
+      expect(updates).lengthOf(5);
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       assertHasUpdate(updates, 'lib/google/cloud/automl/version.rb', VersionRB);
+      assertHasUpdate(
+        updates,
+        'sig/lib/google/cloud/automl/version.rbs',
+        VersionRB
+      );
+      assertHasUpdate(
+        updates,
+        'rbi/lib/google/cloud/automl/version.rbi',
+        VersionRB
+      );
       assertHasUpdate(updates, 'Gemfile.lock', GemfileLock);
     });
     it('allows overriding version file', async () => {
@@ -115,9 +125,11 @@ describe('Ruby', () => {
         latestRelease,
       });
       const updates = release!.updates;
-      expect(updates).lengthOf(3);
+      expect(updates).lengthOf(5);
       assertHasUpdate(updates, 'CHANGELOG.md', Changelog);
       assertHasUpdate(updates, 'lib/foo/version.rb', VersionRB);
+      assertHasUpdate(updates, 'sig/lib/foo/version.rbs', VersionRB);
+      assertHasUpdate(updates, 'rbi/lib/foo/version.rbi', VersionRB);
       assertHasUpdate(updates, 'Gemfile.lock', GemfileLock);
     });
     // TODO: add tests for tag separator


### PR DESCRIPTION
- make Gemfile.lock work by parsing the gemName from the version file
- add support for verison.rbs and version.rbi