### PR TITLE
do not create release pr if only commits are codegen metadata

### DIFF
--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -289,8 +289,14 @@ export abstract class BaseStrategy implements Strategy {
     const mergeCommitRegex =
       /^Merge pull request #\d+ from [^/]+\/release-please(--[\w-]+)+$/;
 
-    // if there are no commits that are not release pr merge commits, there's nothing to include in a new release PR
-    if (commits.every(c => mergeCommitRegex.test(c.message))) {
+    // if there are no commits that are not either release pr merge commits or metadata commits,
+    // there's nothing to include in a new release PR
+    if (
+      commits.every(
+        c =>
+          mergeCommitRegex.test(c.message) || c.message === 'codegen metadata'
+      )
+    ) {
       this.logger.info(
         `No commits to consider for ${this.path}, all commits are merges of release PRs`
       );


### PR DESCRIPTION
it's maybe not amazing to be leaking such specific stainless details into our release-please fork, but this is a lot simpler than doing it on monorepo end