### PR TITLE
do not leave comment if custom version has not been set

### DIFF
--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -22,7 +22,6 @@ import {
   MANIFEST_PULL_REQUEST_TITLE_PATTERN,
   ExtraFile,
   DEFAULT_CUSTOM_VERSION_LABEL,
-  DEFAULT_RELEASE_PLEASE_MANIFEST,
 } from '../manifest';
 import {DefaultVersioningStrategy} from '../versioning-strategies/default';
 import {DefaultChangelogNotes} from '../changelog-notes/default';
@@ -275,14 +274,12 @@ export abstract class BaseStrategy implements Strategy {
     labels = [],
     latestRelease,
     draft,
-    manifestPath,
   }: {
     commits: Commit[];
     latestRelease?: Release;
     draft?: boolean;
     labels?: string[];
     existingPullRequest?: PullRequest;
-    manifestPath?: string;
   }): Promise<ReleasePullRequest | undefined> {
     this.logger.info(`Considering: ${commits.length} raw commits`);
 

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -391,13 +391,7 @@ To set a custom version be sure to use the [semantic versioning format](https://
       } else {
         // look at the manifest from release branch and compare against version from PR title
         try {
-          const manifest =
-            (await this.github.getFileJson<Record<string, string>>(
-              manifestPath || DEFAULT_RELEASE_PLEASE_MANIFEST,
-              existingPullRequest.headBranchName
-            )) || {};
-          const componentVersion = manifest[component || '.'];
-          if (componentVersion !== existingPRTitleVersion?.toString()) {
+          if (newVersion.toString() !== existingPRTitleVersion.toString()) {
             // version from title has been edited, add custom version label, a comment, and use the title version
             this.github.addIssueLabels(
               [DEFAULT_CUSTOM_VERSION_LABEL],

--- a/src/strategies/java.ts
+++ b/src/strategies/java.ts
@@ -79,14 +79,12 @@ export class Java extends BaseStrategy {
     labels = [],
     latestRelease,
     draft,
-    manifestPath,
   }: {
     commits: ConventionalCommit[];
     latestRelease?: Release;
     draft?: boolean;
     labels?: string[];
     existingPullRequest?: PullRequest;
-    manifestPath?: string;
   }): Promise<ReleasePullRequest | undefined> {
     if (await this.needsSnapshot(commits, latestRelease)) {
       this.logger.info('Repository needs a snapshot bump.');
@@ -102,7 +100,6 @@ export class Java extends BaseStrategy {
       latestRelease,
       draft,
       labels,
-      manifestPath,
     });
   }
 

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -2483,6 +2483,17 @@ describe('Manifest', () => {
         .stub(github, 'getFileContentsOnBranch')
         .withArgs('release-please-config.json', 'next')
         .resolves(buildGitHubFileRaw(JSON.stringify(config)))
+        .withArgs('.release-please-manifest.json', 'next')
+        .resolves(
+          buildGitHubFileRaw(
+            JSON.stringify({
+              'path/a': '1.0.0',
+              'path/b': '2.0.0',
+              'path/c': '3.0.0',
+              'path/d': '4.0.0',
+            })
+          )
+        )
         .withArgs('path/b/package.json', 'next')
         .resolves(
           buildGitHubFileRaw(

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -2483,17 +2483,6 @@ describe('Manifest', () => {
         .stub(github, 'getFileContentsOnBranch')
         .withArgs('release-please-config.json', 'next')
         .resolves(buildGitHubFileRaw(JSON.stringify(config)))
-        .withArgs('.release-please-manifest.json', 'next')
-        .resolves(
-          buildGitHubFileRaw(
-            JSON.stringify({
-              'path/a': '1.0.0',
-              'path/b': '2.0.0',
-              'path/c': '3.0.0',
-              'path/d': '4.0.0',
-            })
-          )
-        )
         .withArgs('path/b/package.json', 'next')
         .resolves(
           buildGitHubFileRaw(
@@ -2592,9 +2581,9 @@ version = "3.0.0"
       expect(pullRequests[1].version?.toString()).to.eql('7.8.9');
       expect(pullRequests[2].version?.toString()).to.eql('8.9.0');
       expect(pullRequests[3].version?.toString()).to.eql('9.0.1');
-      sinon.assert.called(getFileContentsOnBranchStub);
       sinon.assert.called(addIssueLabelsStub);
       sinon.assert.called(findFilesByFilenameAndRefStub);
+      sinon.assert.called(getFileContentsOnBranchStub);
       expect(commentCount).to.eql(4);
     });
 

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -2456,106 +2456,6 @@ describe('Manifest', () => {
           },
         },
       ]);
-      const config: ManifestConfig = {
-        'separate-pull-requests': true,
-        'release-type': 'simple',
-        packages: {
-          'path/a': {
-            'release-type': 'simple',
-            component: 'pkg1',
-          },
-          'path/b': {
-            'release-type': 'node',
-            component: 'pkg2',
-          },
-          'path/c': {
-            'release-type': 'python',
-            component: 'pkg3',
-          },
-          'path/d': {
-            'release-type': 'go',
-            component: 'pkg4',
-          },
-        },
-      };
-
-      const getFileContentsOnBranchStub = sandbox
-        .stub(github, 'getFileContentsOnBranch')
-        .withArgs('release-please-config.json', 'next')
-        .resolves(buildGitHubFileRaw(JSON.stringify(config)))
-        .withArgs('.release-please-manifest.json', 'next')
-        .resolves(
-          buildGitHubFileRaw(
-            JSON.stringify({
-              'path/a': '1.0.0',
-              'path/b': '2.0.0',
-              'path/c': '3.0.0',
-              'path/d': '4.0.0',
-            })
-          )
-        )
-        .withArgs(
-          '.release-please-manifest.json',
-          'release-please--branches--main--changes--next--components--pkg1'
-        )
-        .resolves(
-          buildGitHubFileRaw(
-            JSON.stringify({
-              'path/a': '1.0.1',
-            })
-          )
-        )
-        .withArgs(
-          '.release-please-manifest.json',
-          'release-please--branches--main--changes--next--components--pkg2'
-        )
-        .resolves(
-          buildGitHubFileRaw(
-            JSON.stringify({
-              'path/b': '2.0.1',
-            })
-          )
-        )
-        .withArgs('path/b/package.json', 'next')
-        .resolves(
-          buildGitHubFileRaw(
-            JSON.stringify({
-              name: 'pkg2',
-            })
-          )
-        )
-        .withArgs(
-          '.release-please-manifest.json',
-          'release-please--branches--main--changes--next--components--pkg3'
-        )
-        .resolves(
-          buildGitHubFileRaw(
-            JSON.stringify({
-              'path/c': '3.0.1',
-            })
-          )
-        )
-        .withArgs('path/c/setup.py', 'next')
-        .resolves(
-          buildGitHubFileRaw(
-            `
-name = "pkg3"
-description = "Something"
-version = "3.0.0"
-`
-          )
-        )
-        .withArgs(
-          '.release-please-manifest.json',
-          'release-please--branches--main--changes--next--components--pkg4'
-        )
-        .resolves(
-          buildGitHubFileRaw(
-            JSON.stringify({
-              'path/d': '4.0.1',
-            })
-          )
-        );
 
       const findFilesByFilenameAndRefStub = sandbox
         .stub(github, 'findFilesByFilenameAndRef')
@@ -2589,7 +2489,7 @@ version = "3.0.0"
       const pullRequests = await manifest.buildPullRequests(
         [
           {
-            title: 'chore(main): release v6.7.9-alpha.1', // version from title differs from PR manifest
+            title: 'chore(main): release v6.7.9-alpha.1', // version from title differs from expected 4.0.1
             body: 'some content',
             headBranchName:
               'release-please--branches--main--changes--next--components--pkg1',
@@ -2599,7 +2499,7 @@ version = "3.0.0"
             files: [],
           },
           {
-            title: 'chore(main): release v7.8.9', // version from title differs from PR manifest
+            title: 'chore(main): release v7.8.9', // version from title differs from expected 4.0.1
             body: 'some content',
             headBranchName:
               'release-please--branches--main--changes--next--components--pkg2',
@@ -2609,7 +2509,7 @@ version = "3.0.0"
             files: [],
           },
           {
-            title: 'chore(main): release 8.9.0', // version from title differs from PR manifest
+            title: 'chore(main): release 8.9.0', // version from title differs from expected 4.0.1
             body: 'some content',
             headBranchName:
               'release-please--branches--main--changes--next--components--pkg3',
@@ -2619,7 +2519,7 @@ version = "3.0.0"
             files: [],
           },
           {
-            title: 'chore(main): release v9.0.1', // version from title differs from PR manifest
+            title: 'chore(main): release v9.0.1', // version from title differs from expected 4.0.1
             body: 'some content',
             headBranchName:
               'release-please--branches--main--changes--next--components--pkg4',
@@ -2636,7 +2536,6 @@ version = "3.0.0"
       expect(pullRequests[1].version?.toString()).to.eql('7.8.9');
       expect(pullRequests[2].version?.toString()).to.eql('8.9.0');
       expect(pullRequests[3].version?.toString()).to.eql('9.0.1');
-      sinon.assert.called(getFileContentsOnBranchStub);
       sinon.assert.called(addIssueLabelsStub);
       sinon.assert.called(findFilesByFilenameAndRefStub);
       expect(commentCount).to.eql(4);

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -2501,16 +2501,6 @@ describe('Manifest', () => {
               name: 'pkg2',
             })
           )
-        )
-        .withArgs('path/c/setup.py', 'next')
-        .resolves(
-          buildGitHubFileRaw(
-            `
-name = "pkg3"
-description = "Something"
-version = "3.0.0"
-`
-          )
         );
 
       const findFilesByFilenameAndRefStub = sandbox

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -2456,6 +2456,62 @@ describe('Manifest', () => {
           },
         },
       ]);
+      const config: ManifestConfig = {
+        'separate-pull-requests': true,
+        'release-type': 'simple',
+        packages: {
+          'path/a': {
+            'release-type': 'simple',
+            component: 'pkg1',
+          },
+          'path/b': {
+            'release-type': 'node',
+            component: 'pkg2',
+          },
+          'path/c': {
+            'release-type': 'python',
+            component: 'pkg3',
+          },
+          'path/d': {
+            'release-type': 'go',
+            component: 'pkg4',
+          },
+        },
+      };
+
+      const getFileContentsOnBranchStub = sandbox
+        .stub(github, 'getFileContentsOnBranch')
+        .withArgs('release-please-config.json', 'next')
+        .resolves(buildGitHubFileRaw(JSON.stringify(config)))
+        .withArgs('.release-please-manifest.json', 'next')
+        .resolves(
+          buildGitHubFileRaw(
+            JSON.stringify({
+              'path/a': '1.0.0',
+              'path/b': '2.0.0',
+              'path/c': '3.0.0',
+              'path/d': '4.0.0',
+            })
+          )
+        )
+        .withArgs('path/b/package.json', 'next')
+        .resolves(
+          buildGitHubFileRaw(
+            JSON.stringify({
+              name: 'pkg2',
+            })
+          )
+        )
+        .withArgs('path/c/setup.py', 'next')
+        .resolves(
+          buildGitHubFileRaw(
+            `
+name = "pkg3"
+description = "Something"
+version = "3.0.0"
+`
+          )
+        );
 
       const findFilesByFilenameAndRefStub = sandbox
         .stub(github, 'findFilesByFilenameAndRef')
@@ -2536,6 +2592,7 @@ describe('Manifest', () => {
       expect(pullRequests[1].version?.toString()).to.eql('7.8.9');
       expect(pullRequests[2].version?.toString()).to.eql('8.9.0');
       expect(pullRequests[3].version?.toString()).to.eql('9.0.1');
+      sinon.assert.called(getFileContentsOnBranchStub);
       sinon.assert.called(addIssueLabelsStub);
       sinon.assert.called(findFilesByFilenameAndRefStub);
       expect(commentCount).to.eql(4);


### PR DESCRIPTION
<img width="868" height="272" alt="Screenshot 2025-08-01 at 10 13 30 PM" src="https://github.com/user-attachments/assets/00690f66-37e7-49e1-87c4-64e239630009" />
we're getting some bad comments on PRs saying the version has been changed when it hasn't. we should instead be comparing the bumped version with the PR title (not the manifest version, since the manifest could be behind if we failed to create the release commit earlier)