### PR TITLE
fork base and add release commit atomically

### DIFF
--- a/src/strategies/java.ts
+++ b/src/strategies/java.ts
@@ -79,12 +79,14 @@ export class Java extends BaseStrategy {
     labels = [],
     latestRelease,
     draft,
+    manifestPath,
   }: {
     commits: ConventionalCommit[];
     latestRelease?: Release;
     draft?: boolean;
     labels?: string[];
     existingPullRequest?: PullRequest;
+    manifestPath?: string;
   }): Promise<ReleasePullRequest | undefined> {
     if (await this.needsSnapshot(commits, latestRelease)) {
       this.logger.info('Repository needs a snapshot bump.');
@@ -100,6 +102,7 @@ export class Java extends BaseStrategy {
       latestRelease,
       draft,
       labels,
+      manifestPath,
     });
   }
 

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -2494,11 +2494,65 @@ describe('Manifest', () => {
             })
           )
         )
+        .withArgs(
+          '.release-please-manifest.json',
+          'release-please--branches--main--changes--next--components--pkg1'
+        )
+        .resolves(
+          buildGitHubFileRaw(
+            JSON.stringify({
+              'path/a': '1.0.1',
+            })
+          )
+        )
+        .withArgs(
+          '.release-please-manifest.json',
+          'release-please--branches--main--changes--next--components--pkg2'
+        )
+        .resolves(
+          buildGitHubFileRaw(
+            JSON.stringify({
+              'path/b': '2.0.1',
+            })
+          )
+        )
         .withArgs('path/b/package.json', 'next')
         .resolves(
           buildGitHubFileRaw(
             JSON.stringify({
               name: 'pkg2',
+            })
+          )
+        )
+        .withArgs(
+          '.release-please-manifest.json',
+          'release-please--branches--main--changes--next--components--pkg3'
+        )
+        .resolves(
+          buildGitHubFileRaw(
+            JSON.stringify({
+              'path/c': '3.0.1',
+            })
+          )
+        )
+        .withArgs('path/c/setup.py', 'next')
+        .resolves(
+          buildGitHubFileRaw(
+            `
+name = "pkg3"
+description = "Something"
+version = "3.0.0"
+`
+          )
+        )
+        .withArgs(
+          '.release-please-manifest.json',
+          'release-please--branches--main--changes--next--components--pkg4'
+        )
+        .resolves(
+          buildGitHubFileRaw(
+            JSON.stringify({
+              'path/d': '4.0.1',
             })
           )
         );
@@ -2535,7 +2589,7 @@ describe('Manifest', () => {
       const pullRequests = await manifest.buildPullRequests(
         [
           {
-            title: 'chore(main): release v6.7.9-alpha.1', // version from title differs from expected 4.0.1
+            title: 'chore(main): release v6.7.9-alpha.1', // version from title differs from PR manifest
             body: 'some content',
             headBranchName:
               'release-please--branches--main--changes--next--components--pkg1',
@@ -2545,7 +2599,7 @@ describe('Manifest', () => {
             files: [],
           },
           {
-            title: 'chore(main): release v7.8.9', // version from title differs from expected 4.0.1
+            title: 'chore(main): release v7.8.9', // version from title differs from PR manifest
             body: 'some content',
             headBranchName:
               'release-please--branches--main--changes--next--components--pkg2',
@@ -2555,7 +2609,7 @@ describe('Manifest', () => {
             files: [],
           },
           {
-            title: 'chore(main): release 8.9.0', // version from title differs from expected 4.0.1
+            title: 'chore(main): release 8.9.0', // version from title differs from PR manifest
             body: 'some content',
             headBranchName:
               'release-please--branches--main--changes--next--components--pkg3',
@@ -2565,7 +2619,7 @@ describe('Manifest', () => {
             files: [],
           },
           {
-            title: 'chore(main): release v9.0.1', // version from title differs from expected 4.0.1
+            title: 'chore(main): release v9.0.1', // version from title differs from PR manifest
             body: 'some content',
             headBranchName:
               'release-please--branches--main--changes--next--components--pkg4',
@@ -2582,9 +2636,9 @@ describe('Manifest', () => {
       expect(pullRequests[1].version?.toString()).to.eql('7.8.9');
       expect(pullRequests[2].version?.toString()).to.eql('8.9.0');
       expect(pullRequests[3].version?.toString()).to.eql('9.0.1');
+      sinon.assert.called(getFileContentsOnBranchStub);
       sinon.assert.called(addIssueLabelsStub);
       sinon.assert.called(findFilesByFilenameAndRefStub);
-      sinon.assert.called(getFileContentsOnBranchStub);
       expect(commentCount).to.eql(4);
     });
 


### PR DESCRIPTION
We've been running into issues where `commitAndPush` runs into a 422 from GitHub for some unknown reason (I wrote to their support and didn't hear back) and we leave the repo in a state where the release commit is missing. And then if/when we retry the PR title does not match the manifest (because the release commit is missing) so we think that the user edited the PR title.

I tried to mitigate the latter problem with https://github.com/stainless-api/release-please/pull/212 but that caused more issues https://stainless-workspace.slack.com/archives/C06H02ZA5BM/p1754677699040689 so I'm reverting it here.

I've implemented a better fix: just fork `next` and add the release commit atomically rather than as two separate updates to the release branch.